### PR TITLE
update tsconfig outDir to match node-base-image

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "pretty": true,
     "sourceMap": true,
     "target": "es6",
-    "outDir": "./dist/app",
+    "outDir": "./dist",
     "baseUrl": "./src",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Updates the outDir in tsconfig.json to allow service to work with https://github.com/companieshouse/node-base-image