### PR TITLE
Fix uppercase data, remove placeholder and add DOB to officer details

### DIFF
--- a/src/controller/bankrupt/bankrupt-officer.controller.ts
+++ b/src/controller/bankrupt/bankrupt-officer.controller.ts
@@ -1,13 +1,14 @@
 import { Request, Response, NextFunction } from 'express';
 import { fetchBankruptOfficer } from '../../service';
-import { logger } from '../../utils';
+import { logger, formattingOfficersInfo } from '../../utils';
 
 export default async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const bankruptOfficer = await fetchBankruptOfficer(req.params?.id);
 
     if(!bankruptOfficer.error){
-      return res.render('bankrupt_officer', { bankruptOfficer: bankruptOfficer.data || {} });     
+      const officer = (bankruptOfficer.data) ? formattingOfficersInfo([bankruptOfficer.data])[0] : {};
+      return res.render('bankrupt_officer', { bankruptOfficer: officer });
     } else if( bankruptOfficer.status === 500) {
       return res.status(bankruptOfficer.status).render('error-pages/500');
     } else {

--- a/src/controller/bankrupt/bankrupt.controller.ts
+++ b/src/controller/bankrupt/bankrupt.controller.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 
-import { logger } from '../../utils';
+import { logger, formattingOfficersInfo } from '../../utils';
 import { fetchBankruptOfficers } from '../../service';
 import { BankruptOfficerSearchFilters, BankruptOfficerSearchQuery } from '../../types';
 
@@ -31,9 +31,9 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
     const results = await fetchBankruptOfficers(body);
 
     // Not found officers has to be rendered anyway with an empty list 
-    if(!results.error || results.status === 404){      
+    if(!results.error || results.status === 404){
       const { itemsPerPage = 0, startIndex = 0, totalResults = 0, items = [] } = results.data || {};
-      return res.render('bankrupt', { itemsPerPage, startIndex, totalResults, items, searched: true });      
+      return res.render('bankrupt', { itemsPerPage, startIndex, totalResults, items: formattingOfficersInfo(items), searched: true });
     } else {
       return res.status(results.status).render('error-pages/500');
     } 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@ export interface Address {
   county?: string
   postcode?: string
 }
-interface BankruptOfficer extends Address {
+export interface BankruptOfficer extends Address {
   ephemeralKey: string
   forename1?: string
   forename2?: string

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,3 +7,8 @@ export { logger } from "./logger/logger";
  *
  */
 export * as userSession from "./session/session";
+
+/**
+ *
+ */
+export { formattingOfficersInfo } from "./script/formatting";

--- a/src/utils/script/formatting.ts
+++ b/src/utils/script/formatting.ts
@@ -1,0 +1,19 @@
+import { BankruptOfficer } from "types";
+
+export const dateFormatting = (date: string | undefined): string | undefined => {
+  return (date) ? date.split("-").reverse().join("/") : date;
+};
+
+export const firstCharacterUpperCase = (chars: string | undefined): string | undefined => {
+  return (chars) ? chars.charAt(0).toUpperCase() + chars.substring(1).toLowerCase() : chars;
+};
+
+export const formattingOfficersInfo = (officersList: Array<BankruptOfficer>): Array<BankruptOfficer> => {
+  const keysOfBankruptOfficer = ["forename1", "forename2", "surname", "addressLine1", "addressLine2", "addressLine3", "town", "county"];
+
+  return officersList.map( officer => {
+    keysOfBankruptOfficer.forEach( k => officer[k] = firstCharacterUpperCase(officer[k]) );
+    officer.dateOfBirth = dateFormatting(officer.dateOfBirth);
+    return officer;
+  });
+};

--- a/src/views/bankrupt.html
+++ b/src/views/bankrupt.html
@@ -14,12 +14,12 @@
 
 <form method="post">
   <div class="govuk-form-group">
-    <label class="govuk-label" for="surname">Last name</label>
-    <input class="govuk-input govuk-!-width-one-half" id="surname" type="text" name="surname" aria-describedby="surname-hint">
-  </div>
-  <div class="govuk-form-group">
     <label class="govuk-label" for="forename1">First name</label>
     <input class="govuk-input govuk-!-width-one-half" id="forename1" type="text" name="forename1" aria-describedby="forename1-hint">
+  </div>
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="surname">Last name</label>
+    <input class="govuk-input govuk-!-width-one-half" id="surname" type="text" name="surname" aria-describedby="surname-hint">
   </div>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset" role="group" aria-describedby="dob-hint">

--- a/src/views/bankrupt.html
+++ b/src/views/bankrupt.html
@@ -35,7 +35,7 @@
             <label class="govuk-label govuk-date-input__label" for="dob-day">
               Day
             </label>
-            <input class="govuk-input govuk-date-input__input govuk-input--width-2" placeholder="DD" id="dob-dd"
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dob-dd"
               name="dob-dd" autocomplete="bday-day" type="text" pattern="[0-9]*" inputmode="numeric">
           </div>
         </div>
@@ -44,7 +44,7 @@
             <label class="govuk-label govuk-date-input__label" for="dob-mm">
               Month
             </label>
-            <input class="govuk-input govuk-date-input__input govuk-input--width-2" placeholder="MM" id="dob-mm"
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dob-mm"
               name="dob-mm" autocomplete="bday-month" type="text" pattern="[0-9]*" inputmode="numeric">
           </div>
         </div>
@@ -53,7 +53,7 @@
             <label class="govuk-label govuk-date-input__label" for="dob-yyyy">
               Year
             </label>
-            <input class="govuk-input govuk-date-input__input govuk-input--width-4" placeholder="YYYY" id="dob-yyyy"
+            <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="dob-yyyy"
               name="dob-yyyy" autocomplete="bday-year" type="text" pattern="[0-9]*" inputmode="numeric">
           </div>
         </div>

--- a/src/views/bankrupt_officer.html
+++ b/src/views/bankrupt_officer.html
@@ -48,6 +48,12 @@
       </dt>
       <dd class="govuk-summary-list__value">{{ bankruptOfficer.alias }}</dd>
     </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Date of birth
+      </dt>
+      <dd class="govuk-summary-list__value">{{ bankruptOfficer.dateOfBirth }}</dd>
+    </div>
   </dl>
   <h2 class="govuk-heading-m">Address details</h2>
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">

--- a/test/__mocks__/utils.mock.ts
+++ b/test/__mocks__/utils.mock.ts
@@ -1,6 +1,7 @@
 import { 
   BankruptOfficerSearchFilters, 
-  BankruptOfficerSearchQuery 
+  BankruptOfficerSearchQuery,
+  BankruptOfficer
 } from "../../src/types";
 
 export const PAGE_NOT_FOUND = "page not found";
@@ -25,20 +26,25 @@ export const mockSearchQuery: BankruptOfficerSearchQuery = {
   filters: mockFilters
 };
 
+export const mockBankruptOfficer: BankruptOfficer = {
+  ephemeralKey: "B6A94E743AD86973E05400144FFBDD12",
+  forename1: "Kermit",
+  forename2: "The",
+  surname: "Frog",
+  addressLine1: "123 Fake Lane",
+  addressLine2: "456 SECOND LANE",
+  addressLine3: "789 THIRD LANE",
+  town: "Muppet Town",
+  county: "SOME COUNTY",
+  postcode: "MP12 3TW",
+  dateOfBirth: "1940-01-02"
+};
+
 export const BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS = { 
   itemsPerPage: 1, 
   startIndex: 0, 
   totalResults: 1, 
-  items: [{ 
-    ephemeralKey: "B6A94E743AD86973E05400144FFBDD12",
-    forename1: "Kermit",
-    forename2: "The",
-    surname: "Frog",
-    addressLine1: "123 Fake Lane",
-    town: "Muppet Town",
-    postcode: "MP12 3TW",
-    dateOfBirth: "1940-01-01"
-  }]
+  items: [mockBankruptOfficer]
 };
 
 export const BANKRUPT_OFFICER_SEARCH_NO_PAGE_RESULTS = { 
@@ -57,7 +63,7 @@ export const statusCode = {
 export const mockAxiosResponse = { 
   ok: {
     status: statusCode.ok,
-    data: "ok"
+    data: mockBankruptOfficer
   },  
   data_results: {
     status: statusCode.ok,

--- a/test/controller/bankrupt-officer.spec.ts
+++ b/test/controller/bankrupt-officer.spec.ts
@@ -5,11 +5,12 @@ import sinon from "sinon";
 import axios from 'axios';
 
 import { bankruptOfficer } from "../../src/controller";
-import { logger } from '../../src/utils';
+import { logger, formattingOfficersInfo } from '../../src/utils';
 
 import { 
-  mockAxiosResponse, 
-  statusCode 
+  mockAxiosResponse,
+  mockBankruptOfficer,
+  statusCode
 } from '../__mocks__/utils.mock';
 
 chai.use(sinonChai);
@@ -42,13 +43,14 @@ describe('BankruptOfficerController test suite', () => {
   });
 
   it('should return bankruptOfficer with data object and render bankrupt_officer page', async () => {
+    sinon.stub(formattingOfficersInfo([]));
     sinon.stub(axios, 'get').resolves(mockAxiosResponse.ok);
 
     await bankruptOfficer(req, res, nextFunctionSpy);
 
     expect(nextFunctionSpy).not.called;
     expect(res.render).to.have.been.calledOnce;
-    expect(res.render).to.have.been.calledWith('bankrupt_officer', { bankruptOfficer: "ok" });
+    expect(res.render).to.have.been.calledWith('bankrupt_officer', { bankruptOfficer: mockBankruptOfficer });
   });
 
   it('should return bankruptOfficer with status code 500 and render error-pages/500 page', async () => {

--- a/test/utils/scripts.spec.ts
+++ b/test/utils/scripts.spec.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+
+import { mockBankruptOfficer } from "../__mocks__/utils.mock";
+
+import { 
+  dateFormatting, 
+  firstCharacterUpperCase, 
+  formattingOfficersInfo 
+} from "../../src/utils/script/formatting";
+
+describe('Formatting test suite', () => {
+
+  it('Test function dateFormatting', () => {
+    const shouldbe = "02/01/1940";
+    expect(dateFormatting("")).equal("");
+    expect(dateFormatting(undefined)).equal(undefined);
+    expect(dateFormatting(mockBankruptOfficer.dateOfBirth)).equal(shouldbe);
+  });
+
+  it('Test function firstCharacterUpperCase', () => {
+    expect(firstCharacterUpperCase("")).equal("");
+    expect(firstCharacterUpperCase(undefined)).equal(undefined);
+    expect(firstCharacterUpperCase(mockBankruptOfficer.addressLine2)).equal("456 second lane");
+    expect(firstCharacterUpperCase(mockBankruptOfficer.addressLine3)).equal("789 third lane");
+    expect(firstCharacterUpperCase(mockBankruptOfficer.county)).equal("Some county");
+  });
+
+  it('Test function formattingOfficersInfo', () => {
+    const officer = formattingOfficersInfo([mockBankruptOfficer])[0];
+    expect(officer.addressLine2).equal("456 second lane");
+    expect(officer.addressLine3).equal("789 third lane");
+    expect(officer.county).equal("Some county");
+  });
+    
+});


### PR DESCRIPTION
- Remove placeholder text in the date of birth fields (DD, MM, YYYY)
- Fix uppercase officer details
- Fix date of birth to be in DD/MM/YYYY
- Add DOB on bankrupt officer detail page