### PR TITLE
Fixing returned officer results casing

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ export interface BankruptOfficer extends Address {
   ephemeralKey: string
   forename1?: string
   forename2?: string
+  alias?: string
   surname?: string
   dateOfBirth?: string
 }

--- a/src/utils/script/formatting.ts
+++ b/src/utils/script/formatting.ts
@@ -1,4 +1,4 @@
-import { BankruptOfficer } from "types";
+import { FullBankruptOfficer } from "types";
 
 export const dateFormatting = (date: string | undefined): string | undefined => {
   return (date) ? date.split("-").reverse().join("/") : date;
@@ -8,8 +8,8 @@ export const firstCharacterUpperCase = (chars: string | undefined): string | und
   return (chars) ? chars.charAt(0).toUpperCase() + chars.substring(1).toLowerCase() : chars;
 };
 
-export const formattingOfficersInfo = (officersList: Array<BankruptOfficer>): Array<BankruptOfficer> => {
-  const keysOfBankruptOfficer = ["forename1", "forename2", "surname", "addressLine1", "addressLine2", "addressLine3", "town", "county"];
+export const formattingOfficersInfo = (officersList: Array<FullBankruptOfficer>): Array<FullBankruptOfficer> => {
+  const keysOfBankruptOfficer = ["forename1", "forename2", "alias", "surname", "addressLine1", "addressLine2", "addressLine3", "town", "county", "caseType", "bankruptcyType"];
 
   return officersList.map( officer => {
     keysOfBankruptOfficer.forEach( k => officer[k] = firstCharacterUpperCase(officer[k]) );

--- a/test/__mocks__/utils.mock.ts
+++ b/test/__mocks__/utils.mock.ts
@@ -1,7 +1,6 @@
 import { 
   BankruptOfficerSearchFilters, 
   BankruptOfficerSearchQuery,
-  BankruptOfficer,
   FullBankruptOfficer
 } from "../../src/types";
 

--- a/test/__mocks__/utils.mock.ts
+++ b/test/__mocks__/utils.mock.ts
@@ -1,7 +1,8 @@
 import { 
   BankruptOfficerSearchFilters, 
   BankruptOfficerSearchQuery,
-  BankruptOfficer
+  BankruptOfficer,
+  FullBankruptOfficer
 } from "../../src/types";
 
 export const PAGE_NOT_FOUND = "page not found";
@@ -26,25 +27,32 @@ export const mockSearchQuery: BankruptOfficerSearchQuery = {
   filters: mockFilters
 };
 
-export const mockBankruptOfficer: BankruptOfficer = {
+export const mockFullBankruptOfficer: FullBankruptOfficer = {
   ephemeralKey: "B6A94E743AD86973E05400144FFBDD12",
-  forename1: "Kermit",
-  forename2: "The",
-  surname: "Frog",
-  addressLine1: "123 Fake Lane",
+  forename1: "KERMIT",
+  forename2: "THE",
+  alias: "ALIAS",
+  surname: "FROG",
+  dateOfBirth: "1940-01-02",
+  addressLine1: "123 FAKE LANE",
   addressLine2: "456 SECOND LANE",
   addressLine3: "789 THIRD LANE",
-  town: "Muppet Town",
+  town: "MUPPET TOWN",
   county: "SOME COUNTY",
   postcode: "MP12 3TW",
-  dateOfBirth: "1940-01-02"
+  caseType: "TRUST DEED",
+  caseReference: "CASE REFERENCE",
+  bankruptcyType: "BANKRUPTCY TYPE",
+  startDate: "2000-01-02",
+  debtorDischargeDate: "2030-01-02",
+  trusteeDischargeDate: "2030-01-02"
 };
 
 export const BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS = { 
   itemsPerPage: 1, 
   startIndex: 0, 
   totalResults: 1, 
-  items: [mockBankruptOfficer]
+  items: [mockFullBankruptOfficer]
 };
 
 export const BANKRUPT_OFFICER_SEARCH_NO_PAGE_RESULTS = { 
@@ -63,7 +71,7 @@ export const statusCode = {
 export const mockAxiosResponse = { 
   ok: {
     status: statusCode.ok,
-    data: mockBankruptOfficer
+    data: mockFullBankruptOfficer
   },  
   data_results: {
     status: statusCode.ok,

--- a/test/controller/bankrupt-officer.spec.ts
+++ b/test/controller/bankrupt-officer.spec.ts
@@ -9,7 +9,7 @@ import { logger, formattingOfficersInfo } from '../../src/utils';
 
 import { 
   mockAxiosResponse,
-  mockBankruptOfficer,
+  mockFullBankruptOfficer,
   statusCode
 } from '../__mocks__/utils.mock';
 
@@ -50,7 +50,7 @@ describe('BankruptOfficerController test suite', () => {
 
     expect(nextFunctionSpy).not.called;
     expect(res.render).to.have.been.calledOnce;
-    expect(res.render).to.have.been.calledWith('bankrupt_officer', { bankruptOfficer: mockBankruptOfficer });
+    expect(res.render).to.have.been.calledWith('bankrupt_officer', { bankruptOfficer: mockFullBankruptOfficer });
   });
 
   it('should return bankruptOfficer with status code 500 and render error-pages/500 page', async () => {

--- a/test/utils/scripts.spec.ts
+++ b/test/utils/scripts.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { mockBankruptOfficer } from "../__mocks__/utils.mock";
+import { mockFullBankruptOfficer } from "../__mocks__/utils.mock";
 
 import { 
   dateFormatting, 
@@ -14,22 +14,38 @@ describe('Formatting test suite', () => {
     const shouldbe = "02/01/1940";
     expect(dateFormatting("")).equal("");
     expect(dateFormatting(undefined)).equal(undefined);
-    expect(dateFormatting(mockBankruptOfficer.dateOfBirth)).equal(shouldbe);
+    expect(dateFormatting(mockFullBankruptOfficer.dateOfBirth)).equal(shouldbe);
   });
 
   it('Test function firstCharacterUpperCase', () => {
     expect(firstCharacterUpperCase("")).equal("");
     expect(firstCharacterUpperCase(undefined)).equal(undefined);
-    expect(firstCharacterUpperCase(mockBankruptOfficer.addressLine2)).equal("456 second lane");
-    expect(firstCharacterUpperCase(mockBankruptOfficer.addressLine3)).equal("789 third lane");
-    expect(firstCharacterUpperCase(mockBankruptOfficer.county)).equal("Some county");
+    expect(firstCharacterUpperCase(mockFullBankruptOfficer.forename1)).equal("Kermit");
+    expect(firstCharacterUpperCase(mockFullBankruptOfficer.forename2)).equal("The");
+    expect(firstCharacterUpperCase(mockFullBankruptOfficer.alias)).equal("Alias");
+    expect(firstCharacterUpperCase(mockFullBankruptOfficer.surname)).equal("Frog");
+    expect(firstCharacterUpperCase(mockFullBankruptOfficer.addressLine1)).equal("123 fake lane");
+    expect(firstCharacterUpperCase(mockFullBankruptOfficer.addressLine2)).equal("456 second lane");
+    expect(firstCharacterUpperCase(mockFullBankruptOfficer.addressLine3)).equal("789 third lane");
+    expect(firstCharacterUpperCase(mockFullBankruptOfficer.town)).equal("Muppet town");
+    expect(firstCharacterUpperCase(mockFullBankruptOfficer.county)).equal("Some county");
+    expect(firstCharacterUpperCase(mockFullBankruptOfficer.caseType)).equal("Trust deed");
+    expect(firstCharacterUpperCase(mockFullBankruptOfficer.bankruptcyType)).equal("Bankruptcy type");
   });
 
   it('Test function formattingOfficersInfo', () => {
-    const officer = formattingOfficersInfo([mockBankruptOfficer])[0];
+    const officer = formattingOfficersInfo([mockFullBankruptOfficer])[0];
+    expect(officer.forename1).equal("Kermit");
+    expect(officer.forename2).equal("The");
+    expect(officer.alias).equal("Alias");
+    expect(officer.surname).equal("Frog");
+    expect(officer.addressLine1).equal("123 fake lane");
     expect(officer.addressLine2).equal("456 second lane");
     expect(officer.addressLine3).equal("789 third lane");
+    expect(officer.town).equal("Muppet town");
     expect(officer.county).equal("Some county");
+    expect(officer.caseType).equal("Trust deed");
+    expect(officer.bankruptcyType).equal("Bankruptcy type");
   });
     
 });


### PR DESCRIPTION
Displaying officer results in sentence case instead of upper case, adding extra unit tests and adding the `alias` field onto the model

Resolves: [BI-6855](https://companieshouse.atlassian.net/browse/BI-6855)