### PR TITLE
Fixing returned officer date formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "govuk-frontend": "^3.10.1",
     "helmet": "^4.2.0",
     "ioredis": "^4.19.4",
+    "moment": "^2.29.1",
     "nunjucks": "^3.2.2",
     "validator": "^13.5.2",
     "yargs": "^16.2.0"

--- a/src/utils/script/formatting.ts
+++ b/src/utils/script/formatting.ts
@@ -1,34 +1,28 @@
 import moment from "moment";
 import { FullBankruptOfficer } from "types";
 
+const DISPLAY_DATE_FORMAT: string = "D MMMM YYYY";
+
+export const dateOfBirthFormatting = (date: string | undefined): string | undefined => {
+  return (date) ? date.split("-").reverse().join("/") : date;
+};
+
+export const formatDateForDisplay = (inputDate: string | undefined): string | undefined => {
+  return (inputDate) ? moment(inputDate).format(DISPLAY_DATE_FORMAT) : inputDate;
+};
+
 export const firstCharacterUpperCase = (chars: string | undefined): string | undefined => {
   return (chars) ? chars.charAt(0).toUpperCase() + chars.substring(1).toLowerCase() : chars;
 };
 
 export const formattingOfficersInfo = (officersList: Array<FullBankruptOfficer>): Array<FullBankruptOfficer> => {
   const keysOfBankruptOfficer = ["forename1", "forename2", "alias", "surname", "addressLine1", "addressLine2", "addressLine3", "town", "county", "caseType", "bankruptcyType"];
+  const dateToBeFormatted = ["debtorDischargeDate", "trusteeDischargeDate", "startDate"];
 
   return officersList.map( officer => {
     keysOfBankruptOfficer.forEach( k => officer[k] = firstCharacterUpperCase(officer[k]) );
-    formatDatesForDisplay(officer);
+    dateToBeFormatted.forEach( k => officer[k] = formatDateForDisplay(officer[k]) );
+    officer.dateOfBirth = dateOfBirthFormatting(officer.dateOfBirth);
     return officer;
   });
 };
-
-function formatDatesForDisplay(officer: FullBankruptOfficer) {
-  if (officer.dateOfBirth != null) {
-    officer.dateOfBirth = moment(officer.dateOfBirth, 'YYYY-MM-DD').format('DD/MM/YYYY');
-  }
-
-  if (officer.startDate != null) {
-    officer.startDate = moment(officer.startDate, 'YYYY-MM-DD').format('D MMMM YYYY');
-  }
-
-  if (officer.debtorDischargeDate != null) {
-    officer.debtorDischargeDate = moment(officer.debtorDischargeDate, 'YYYY-MM-DD').format('D MMMM YYYY');
-  }
-  
-  if (officer.trusteeDischargeDate != null) {
-    officer.trusteeDischargeDate = moment(officer.trusteeDischargeDate, 'YYYY-MM-DD').format('D MMMM YYYY');
-  }
-}

--- a/src/utils/script/formatting.ts
+++ b/src/utils/script/formatting.ts
@@ -17,19 +17,18 @@ export const formattingOfficersInfo = (officersList: Array<FullBankruptOfficer>)
 
 function formatDatesForDisplay(officer: FullBankruptOfficer) {
   if (officer.dateOfBirth != null) {
-    officer.dateOfBirth = moment(officer.dateOfBirth, 'DD-MM-YYY').format('L');
+    officer.dateOfBirth = moment(officer.dateOfBirth, 'YYYY-MM-DD').format('DD/MM/YYYY');
   }
 
   if (officer.startDate != null) {
-    officer.startDate = moment(officer.startDate, 'DD-MM-YYY').format('D MMMM YYYY');
+    officer.startDate = moment(officer.startDate, 'YYYY-MM-DD').format('D MMMM YYYY');
   }
 
   if (officer.debtorDischargeDate != null) {
-    officer.debtorDischargeDate = moment(officer.debtorDischargeDate, 'DD-MM-YYY').format('D MMMM YYYY');
+    officer.debtorDischargeDate = moment(officer.debtorDischargeDate, 'YYYY-MM-DD').format('D MMMM YYYY');
   }
   
   if (officer.trusteeDischargeDate != null) {
-    officer.trusteeDischargeDate = moment(officer.trusteeDischargeDate, 'DD-MM-YYY').format('D MMMM YYYY');
+    officer.trusteeDischargeDate = moment(officer.trusteeDischargeDate, 'YYYY-MM-DD').format('D MMMM YYYY');
   }
 }
-

--- a/src/utils/script/formatting.ts
+++ b/src/utils/script/formatting.ts
@@ -1,8 +1,5 @@
+import moment from "moment";
 import { FullBankruptOfficer } from "types";
-
-export const dateFormatting = (date: string | undefined): string | undefined => {
-  return (date) ? date.split("-").reverse().join("/") : date;
-};
 
 export const firstCharacterUpperCase = (chars: string | undefined): string | undefined => {
   return (chars) ? chars.charAt(0).toUpperCase() + chars.substring(1).toLowerCase() : chars;
@@ -13,7 +10,26 @@ export const formattingOfficersInfo = (officersList: Array<FullBankruptOfficer>)
 
   return officersList.map( officer => {
     keysOfBankruptOfficer.forEach( k => officer[k] = firstCharacterUpperCase(officer[k]) );
-    officer.dateOfBirth = dateFormatting(officer.dateOfBirth);
+    formatDatesForDisplay(officer);
     return officer;
   });
 };
+
+function formatDatesForDisplay(officer: FullBankruptOfficer) {
+  if (officer.dateOfBirth != null) {
+    officer.dateOfBirth = moment(officer.dateOfBirth, 'DD-MM-YYY').format('L');
+  }
+
+  if (officer.startDate != null) {
+    officer.startDate = moment(officer.startDate, 'DD-MM-YYY').format('D MMMM YYYY');
+  }
+
+  if (officer.debtorDischargeDate != null) {
+    officer.debtorDischargeDate = moment(officer.debtorDischargeDate, 'DD-MM-YYY').format('D MMMM YYYY');
+  }
+  
+  if (officer.trusteeDischargeDate != null) {
+    officer.trusteeDischargeDate = moment(officer.trusteeDischargeDate, 'DD-MM-YYY').format('D MMMM YYYY');
+  }
+}
+

--- a/test/__mocks__/utils.mock.ts
+++ b/test/__mocks__/utils.mock.ts
@@ -32,7 +32,7 @@ export const mockFullBankruptOfficer: FullBankruptOfficer = {
   forename2: "THE",
   alias: "ALIAS",
   surname: "FROG",
-  dateOfBirth: "1940-01-02",
+  dateOfBirth: "20-06-1997",
   addressLine1: "123 FAKE LANE",
   addressLine2: "456 SECOND LANE",
   addressLine3: "789 THIRD LANE",

--- a/test/__mocks__/utils.mock.ts
+++ b/test/__mocks__/utils.mock.ts
@@ -32,7 +32,7 @@ export const mockFullBankruptOfficer: FullBankruptOfficer = {
   forename2: "THE",
   alias: "ALIAS",
   surname: "FROG",
-  dateOfBirth: "20-06-1997",
+  dateOfBirth: "1950-05-18",
   addressLine1: "123 FAKE LANE",
   addressLine2: "456 SECOND LANE",
   addressLine3: "789 THIRD LANE",

--- a/test/utils/scripts.spec.ts
+++ b/test/utils/scripts.spec.ts
@@ -4,10 +4,26 @@ import { mockFullBankruptOfficer } from "../__mocks__/utils.mock";
 
 import { 
   firstCharacterUpperCase, 
+  formatDateForDisplay,
+  dateOfBirthFormatting,
   formattingOfficersInfo 
 } from "../../src/utils/script/formatting";
 
 describe('Formatting test suite', () => {
+
+  it('Test function dateFormatting', () => {
+    expect(dateOfBirthFormatting("")).equal("");
+    expect(dateOfBirthFormatting(undefined)).equal(undefined);
+    expect(dateOfBirthFormatting(mockFullBankruptOfficer.dateOfBirth)).equal("18/05/1950");
+  });
+
+  it('Test function formatDateForDisplay', () => {
+    expect("").equal("");
+    expect(formatDateForDisplay(undefined)).equal(undefined);
+    expect(formatDateForDisplay(mockFullBankruptOfficer.startDate)).equal("2 January 2000");
+    expect(formatDateForDisplay(mockFullBankruptOfficer.debtorDischargeDate)).equal("2 January 2030");
+    expect(formatDateForDisplay(mockFullBankruptOfficer.trusteeDischargeDate)).equal("2 January 2030");
+  });
 
   it('Test function firstCharacterUpperCase', () => {
     expect(firstCharacterUpperCase("")).equal("");
@@ -42,7 +58,6 @@ describe('Formatting test suite', () => {
     expect(officer.startDate).equal("2 January 2000");
     expect(officer.debtorDischargeDate).equal("2 January 2030");
     expect(officer.trusteeDischargeDate).equal("2 January 2030");
-    console.log(officer);
   });
     
 });

--- a/test/utils/scripts.spec.ts
+++ b/test/utils/scripts.spec.ts
@@ -31,7 +31,7 @@ describe('Formatting test suite', () => {
     expect(officer.forename2).equal("The");
     expect(officer.alias).equal("Alias");
     expect(officer.surname).equal("Frog");
-    expect(officer.dateOfBirth).equal("20/06/1997");
+    expect(officer.dateOfBirth).equal("18/05/1950");
     expect(officer.addressLine1).equal("123 fake lane");
     expect(officer.addressLine2).equal("456 second lane");
     expect(officer.addressLine3).equal("789 third lane");
@@ -39,9 +39,10 @@ describe('Formatting test suite', () => {
     expect(officer.county).equal("Some county");
     expect(officer.caseType).equal("Trust deed");
     expect(officer.bankruptcyType).equal("Bankruptcy type");
-    expect(officer.startDate).equal("2000-01-02");
-    expect(officer.debtorDischargeDate).equal("2030-01-02");
-    expect(officer.trusteeDischargeDate).equal("2030-01-02");
+    expect(officer.startDate).equal("2 January 2000");
+    expect(officer.debtorDischargeDate).equal("2 January 2030");
+    expect(officer.trusteeDischargeDate).equal("2 January 2030");
+    console.log(officer);
   });
     
 });

--- a/test/utils/scripts.spec.ts
+++ b/test/utils/scripts.spec.ts
@@ -3,19 +3,11 @@ import { expect } from 'chai';
 import { mockFullBankruptOfficer } from "../__mocks__/utils.mock";
 
 import { 
-  dateFormatting, 
   firstCharacterUpperCase, 
   formattingOfficersInfo 
 } from "../../src/utils/script/formatting";
 
 describe('Formatting test suite', () => {
-
-  it('Test function dateFormatting', () => {
-    const shouldbe = "02/01/1940";
-    expect(dateFormatting("")).equal("");
-    expect(dateFormatting(undefined)).equal(undefined);
-    expect(dateFormatting(mockFullBankruptOfficer.dateOfBirth)).equal(shouldbe);
-  });
 
   it('Test function firstCharacterUpperCase', () => {
     expect(firstCharacterUpperCase("")).equal("");
@@ -39,6 +31,7 @@ describe('Formatting test suite', () => {
     expect(officer.forename2).equal("The");
     expect(officer.alias).equal("Alias");
     expect(officer.surname).equal("Frog");
+    expect(officer.dateOfBirth).equal("20/06/1997");
     expect(officer.addressLine1).equal("123 fake lane");
     expect(officer.addressLine2).equal("456 second lane");
     expect(officer.addressLine3).equal("789 third lane");
@@ -46,6 +39,9 @@ describe('Formatting test suite', () => {
     expect(officer.county).equal("Some county");
     expect(officer.caseType).equal("Trust deed");
     expect(officer.bankruptcyType).equal("Bankruptcy type");
+    expect(officer.startDate).equal("2000-01-02");
+    expect(officer.debtorDischargeDate).equal("2030-01-02");
+    expect(officer.trusteeDischargeDate).equal("2030-01-02");
   });
     
 });


### PR DESCRIPTION
Fixing returned officer date formats including: `debtorDischargeDate`, `trusteeDischargeDate`, `startDate`

Resolves: [BI-6609](https://companieshouse.atlassian.net/browse/BI-6609)