### PR TITLE
Feature/bi 11924 update discharge date results and details pages

### DIFF
--- a/src/controller/bankrupt/bankrupt.controller.ts
+++ b/src/controller/bankrupt/bankrupt.controller.ts
@@ -1,8 +1,10 @@
 import { NextFunction, Request, Response } from 'express';
 
 import { logger, formattingOfficersInfo, userSession } from '../../utils';
-import { fetchBankruptOfficers } from '../../service';
-import { BankruptOfficerSearchFilters, BankruptOfficerSearchQuery } from '../../types';
+import { fetchBankruptOfficers, fetchBankruptOfficer } from '../../service';
+import { BankruptOfficerSearchFilters, BankruptOfficerSearchQuery, FullBankruptOfficer } from '../../types';
+import { bankruptOfficer } from 'controller';
+import { off } from 'process';
 
 export const getSearchPage = (req: Request, res: Response, next: NextFunction): void => {
   try {
@@ -17,7 +19,7 @@ export const getSearchPage = (req: Request, res: Response, next: NextFunction): 
 export const postSearchPage = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     // Get data from request body - dateOfBirth needs to be checked 
-    const { forename1 = '', surname = '', postcode = '' } = req.body;
+    const { forename1 = '', surname = '', postcode = ''} = req.body;
 
     // Deal with fragmented date of birth
     const dateOfBirth = 
@@ -25,15 +27,36 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
         `${req.body["dob-yyyy"]}-${req.body["dob-mm"]}-${req.body["dob-dd"]}` : '';
 
     // Set post query data
-    const filters: BankruptOfficerSearchFilters = { forename1, surname, dateOfBirth, postcode };
+    const filters: BankruptOfficerSearchFilters = { forename1, surname, dateOfBirth, postcode};
     const body: BankruptOfficerSearchQuery = { startIndex: 0, itemsPerPage: 10, filters};
 
+ 
+    
+
     const results = await fetchBankruptOfficers(req.session, body);
+    const bankruptOfficers: any[] = []; 
+    
+    logger.info("pulled in" );
     // Not found officers has to be rendered anyway with an empty list 
     if(results.httpStatusCode === 404  || results.httpStatusCode === 200){
       const userEmail = userSession.getLoggedInUserEmail(req.session);
       const { itemsPerPage = 0, startIndex = 0, totalResults = 0, items = [] } = results.resource || {};
-      return res.render('bankrupt', { itemsPerPage, startIndex, totalResults, items: formattingOfficersInfo(items), searched: true, userEmail });
+      for (const item in items){
+        items[item];
+        const bankruptOfficerObj = await fetchBankruptOfficer(req.session, items[item].ephemeralKey);
+        const officer = (bankruptOfficerObj.resource) ? formattingOfficersInfo([bankruptOfficerObj.resource])[0] : {};
+        // officersList.push(JSON.stringify(bankruptOfficerObj.resource?.debtorDischargeDate));
+        // let officerIndv;
+        // const officer: FullBankruptOfficer = (bankruptOfficerObj.resource) ? formattingOfficersInfo([bankruptOfficerObj.resource])[0] : officerIndv;
+        
+        bankruptOfficers.push(bankruptOfficerObj);
+        logger.info("office lists : " + JSON.stringify(bankruptOfficerObj));
+        logger.info("PLAIN OLD items lists : " + JSON.stringify(items));
+ 
+      }
+      logger.info("office lists2 : " + JSON.stringify(bankruptOfficers));
+      logger.info("items : " + JSON.stringify(items));
+      return res.render('bankrupt', { itemsPerPage, startIndex, totalResults, items: formattingOfficersInfo(items), bankruptOfficers: bankruptOfficers ,  searched: true, userEmail });
     } else {
       return res.status(results.httpStatusCode).render('error-pages/500');
     } 
@@ -43,3 +66,19 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
     next(err);
   }
 };
+
+
+// for (const item in items){
+      //   items[item];
+      //   const bankruptOfficerObj = await fetchBankruptOfficer(req.session, items[item].ephemeralKey);
+      //   // const officer = (bankruptOfficerObj.resource) ? formattingOfficersInfo([bankruptOfficerObj.resource])[0] : {};
+      //   officersList.push(JSON.stringify(bankruptOfficerObj.resource?.debtorDischargeDate));
+          
+      // //   const officer = (bankruptOfficer.resource) ? formattingOfficersInfo([bankruptOfficer.resource])[0] : {};
+      // //   officersList.push.apply(officer);
+      //   logger.info("office lists : " + officersList);
+      // }
+      // const officer = (bankruptOfficer.resource) ? formattingOfficersInfo([bankruptOfficer.resource])[0] : {};
+        
+      // officersList.push(bankruptOfficer)
+    //}

--- a/src/controller/bankrupt/bankrupt.controller.ts
+++ b/src/controller/bankrupt/bankrupt.controller.ts
@@ -30,6 +30,7 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
     const body: BankruptOfficerSearchQuery = { startIndex: 0, itemsPerPage: 10, filters};
 
     const results = await fetchBankruptOfficers(req.session, body);
+      // Not found officers has to be rendered anyway with an empty list 
    
     if(results.httpStatusCode === 404  || results.httpStatusCode === 200){
       const userEmail = userSession.getLoggedInUserEmail(req.session);

--- a/src/controller/bankrupt/bankrupt.controller.ts
+++ b/src/controller/bankrupt/bankrupt.controller.ts
@@ -2,9 +2,8 @@ import { NextFunction, Request, Response } from 'express';
 
 import { logger, formattingOfficersInfo, userSession } from '../../utils';
 import { fetchBankruptOfficers, fetchBankruptOfficer } from '../../service';
-import { BankruptOfficerSearchFilters, BankruptOfficerSearchQuery, FullBankruptOfficer } from '../../types';
-import { bankruptOfficer } from 'controller';
-import { off } from 'process';
+import { BankruptOfficerSearchFilters, BankruptOfficerSearchQuery } from '../../types';
+
 
 export const getSearchPage = (req: Request, res: Response, next: NextFunction): void => {
   try {
@@ -30,37 +29,17 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
     const filters: BankruptOfficerSearchFilters = { forename1, surname, dateOfBirth, postcode};
     const body: BankruptOfficerSearchQuery = { startIndex: 0, itemsPerPage: 10, filters};
 
- 
-    
-
     const results = await fetchBankruptOfficers(req.session, body);
-    const bankruptOfficers: any[] = []; 
-    
-    logger.info("pulled in" );
-    // Not found officers has to be rendered anyway with an empty list 
+    logger.info(JSON.stringify(results));
+   
     if(results.httpStatusCode === 404  || results.httpStatusCode === 200){
       const userEmail = userSession.getLoggedInUserEmail(req.session);
       const { itemsPerPage = 0, startIndex = 0, totalResults = 0, items = [] } = results.resource || {};
-      for (const item in items){
-        items[item];
-        const bankruptOfficerObj = await fetchBankruptOfficer(req.session, items[item].ephemeralKey);
-        const officer = (bankruptOfficerObj.resource) ? formattingOfficersInfo([bankruptOfficerObj.resource])[0] : {};
-        // officersList.push(JSON.stringify(bankruptOfficerObj.resource?.debtorDischargeDate));
-        // let officerIndv;
-        // const officer: FullBankruptOfficer = (bankruptOfficerObj.resource) ? formattingOfficersInfo([bankruptOfficerObj.resource])[0] : officerIndv;
-        
-        bankruptOfficers.push(bankruptOfficerObj);
-        logger.info("office lists : " + JSON.stringify(bankruptOfficerObj));
-        logger.info("PLAIN OLD items lists : " + JSON.stringify(items));
- 
-      }
-      logger.info("office lists2 : " + JSON.stringify(bankruptOfficers));
-      logger.info("items : " + JSON.stringify(items));
-      return res.render('bankrupt', { itemsPerPage, startIndex, totalResults, items: formattingOfficersInfo(items), bankruptOfficers: bankruptOfficers ,  searched: true, userEmail });
+      const bankruptOfficers = await retrieveDebtorDischarge(req, items);
+      return res.render('bankrupt', { itemsPerPage, startIndex, totalResults, items: formattingOfficersInfo(items), bankruptOfficers:bankruptOfficers, searched: true, userEmail });
     } else {
       return res.status(results.httpStatusCode).render('error-pages/500');
     } 
-
   } catch (err) {
     logger.error(`${err}`);
     next(err);
@@ -68,17 +47,14 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
 };
 
 
-// for (const item in items){
-      //   items[item];
-      //   const bankruptOfficerObj = await fetchBankruptOfficer(req.session, items[item].ephemeralKey);
-      //   // const officer = (bankruptOfficerObj.resource) ? formattingOfficersInfo([bankruptOfficerObj.resource])[0] : {};
-      //   officersList.push(JSON.stringify(bankruptOfficerObj.resource?.debtorDischargeDate));
-          
-      // //   const officer = (bankruptOfficer.resource) ? formattingOfficersInfo([bankruptOfficer.resource])[0] : {};
-      // //   officersList.push.apply(officer);
-      //   logger.info("office lists : " + officersList);
-      // }
-      // const officer = (bankruptOfficer.resource) ? formattingOfficersInfo([bankruptOfficer.resource])[0] : {};
-        
-      // officersList.push(bankruptOfficer)
-    //}
+async function retrieveDebtorDischarge(req,  items ){
+  const bankruptOfficersList: unknown[] = []; 
+  for (const item in items){
+    items[item];
+    const bankruptOfficer = await fetchBankruptOfficer(req.session, items[item].ephemeralKey);
+    const officer = (bankruptOfficer.resource) ? formattingOfficersInfo([bankruptOfficer.resource])[0] : {};
+    bankruptOfficersList.push(officer);
+  }
+  return bankruptOfficersList;
+}
+  

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,13 +7,13 @@ export interface Address {
   postcode?: string
 }
 export interface BankruptOfficer extends Address {
-  debtorDischargeDate?: string
   ephemeralKey: string
   forename1?: string
   forename2?: string
   alias?: string
   surname?: string
   dateOfBirth?: string
+  debtorDischargeDate?: string
 }
 export interface FullBankruptOfficer extends BankruptOfficer {
   caseReference?: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ export interface Address {
   postcode?: string
 }
 export interface BankruptOfficer extends Address {
+  debtorDischargeDate?: string
   ephemeralKey: string
   forename1?: string
   forename2?: string
@@ -19,7 +20,6 @@ export interface FullBankruptOfficer extends BankruptOfficer {
   caseType?: string
   bankruptcyType?: string
   startDate?: string
-  debtorDischargeDate?: string
   trusteeDischargeDate?: string
 }
 export interface BankruptOfficerSearchQuery {

--- a/src/views/bankrupt.html
+++ b/src/views/bankrupt.html
@@ -86,17 +86,22 @@
           <th scope="col" class="govuk-table__header">Last name</th>
           <th scope="col" class="govuk-table__header">Date of birth</th>
           <th scope="col" class="govuk-table__header govuk--width-one-quarter">Postcode</th>
+          <th scope="col" class="govuk-table__header govuk--width-one-quarter">Debtor Discharge Date</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        {% for item in items %}
+        {% for bankruptOfficer in bankruptOfficers  %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><a href='/admin/officer-search/scottish-bankrupt-officer/{{ item.ephemeralKey }}' class='govuk-link'>{{ item.forename1 }}</a></td>
-          <td class="govuk-table__cell">{{ item.surname }}</td>
-          <td class="govuk-table__cell">{{ item.dateOfBirth }}</td>
-          <td class="govuk-table__cell">{{ item.postcode }}</td>
-        </tr>
-        {% endfor %}
+          <td class="govuk-table__cell"><a href='/admin/officer-search/scottish-bankrupt-officer/{{ bankruptOfficer.resource.ephemeralKey }}' class='govuk-link'>{{ bankruptOfficer.resource.forename1 }}</a></td>
+          <td class="govuk-table__cell">{{ bankruptOfficer.resource.surname }}</td>
+          <td class="govuk-table__cell">{{ bankruptOfficer.resource.dateOfBirth }}</td>
+          <td class="govuk-table__cell">{{ bankruptOfficer.resource.postcode }}</td>
+          
+          <td class="govuk-table__cell">{{  bankruptOfficer.resource.debtorDischargeDate }}</td>
+{% endfor %}
+
+
+      </tr>
       </tbody>
     </table>
     {% if not items or not items|length %}

--- a/src/views/bankrupt.html
+++ b/src/views/bankrupt.html
@@ -84,7 +84,7 @@
           <th scope="col" class="govuk-table__header">First name</th>
           <th scope="col" class="govuk-table__header">Last name</th>
           <th scope="col" class="govuk-table__header">Date of birth</th>
-          <th scope="col" class="govuk-table__header govuk--width-one-quarter">Postcode</th>
+          <th scope="col" class="govuk-table__header">Postcode</th>
           <th scope="col" class="govuk-table__header govuk--width-one-quarter">Debtor Discharge Date</th>
         </tr>
       </thead>

--- a/src/views/bankrupt.html
+++ b/src/views/bankrupt.html
@@ -70,7 +70,6 @@
   <button class="govuk-button" data-module="govuk-button">
     Search
   </button>
-
 </form>
 
 {% if searched %}
@@ -90,17 +89,14 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        {% for bankruptOfficer in bankruptOfficers  %}
+        {% for item in items %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><a href='/admin/officer-search/scottish-bankrupt-officer/{{ bankruptOfficer.ephemeralKey }}' class='govuk-link'>{{ bankruptOfficer.forename1 }}</a></td>
-          <td class="govuk-table__cell">{{ bankruptOfficer.surname }}</td>
-          <td class="govuk-table__cell">{{ bankruptOfficer.dateOfBirth }}</td>
-          <td class="govuk-table__cell">{{ bankruptOfficer.postcode }}</td>
-          
-          <td class="govuk-table__cell">{{  bankruptOfficer.debtorDischargeDate }}</td>
-{% endfor %}
-
-
+          <td class="govuk-table__cell"><a href='/admin/officer-search/scottish-bankrupt-officer/{{ item.ephemeralKey }}' class='govuk-link'>{{ item.forename1 }}</a></td>
+          <td class="govuk-table__cell">{{ item.surname }}</td>
+          <td class="govuk-table__cell">{{ item.dateOfBirth }}</td>
+          <td class="govuk-table__cell">{{ item.postcode }}</td>
+          <td class="govuk-table__cell">{{ item.debtorDischargeDate }}</td>
+        {% endfor %}
       </tr>
       </tbody>
     </table>
@@ -109,5 +105,4 @@
     {% endif %}
   </div>
 {% endif %}
-
 {% endblock %}

--- a/src/views/bankrupt.html
+++ b/src/views/bankrupt.html
@@ -92,12 +92,12 @@
       <tbody class="govuk-table__body">
         {% for bankruptOfficer in bankruptOfficers  %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><a href='/admin/officer-search/scottish-bankrupt-officer/{{ bankruptOfficer.resource.ephemeralKey }}' class='govuk-link'>{{ bankruptOfficer.resource.forename1 }}</a></td>
-          <td class="govuk-table__cell">{{ bankruptOfficer.resource.surname }}</td>
-          <td class="govuk-table__cell">{{ bankruptOfficer.resource.dateOfBirth }}</td>
-          <td class="govuk-table__cell">{{ bankruptOfficer.resource.postcode }}</td>
+          <td class="govuk-table__cell"><a href='/admin/officer-search/scottish-bankrupt-officer/{{ bankruptOfficer.ephemeralKey }}' class='govuk-link'>{{ bankruptOfficer.forename1 }}</a></td>
+          <td class="govuk-table__cell">{{ bankruptOfficer.surname }}</td>
+          <td class="govuk-table__cell">{{ bankruptOfficer.dateOfBirth }}</td>
+          <td class="govuk-table__cell">{{ bankruptOfficer.postcode }}</td>
           
-          <td class="govuk-table__cell">{{  bankruptOfficer.resource.debtorDischargeDate }}</td>
+          <td class="govuk-table__cell">{{  bankruptOfficer.debtorDischargeDate }}</td>
 {% endfor %}
 
 

--- a/src/views/bankrupt_officer.html
+++ b/src/views/bankrupt_officer.html
@@ -54,11 +54,20 @@
       </dt>
       <dd class="govuk-summary-list__value">{{ bankruptOfficer.dateOfBirth }}</dd>
     </div>
+  </dl>
+  <h2 class="govuk-heading-m">Discharge dates</h2>
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
         Debtor Discharge Date
       </dt>
       <dd class="govuk-summary-list__value">{{ bankruptOfficer.debtorDischargeDate }}</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Trustee discharge date
+      </dt>
+      <dd class="govuk-summary-list__value">{{ bankruptOfficer.trusteeDischargeDate }}</dd>
     </div>
   </dl>
   <h2 class="govuk-heading-m">Address details</h2>
@@ -126,12 +135,6 @@
       <dd class="govuk-summary-list__value">{{ bankruptOfficer.startDate }}</dd>
     </div>
   </dl>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Trustee discharge date
-      </dt>
-      <dd class="govuk-summary-list__value">{{ bankruptOfficer.trusteeDischargeDate }}</dd>
-    </div>
   </dl>
 
 {% endblock %}

--- a/src/views/bankrupt_officer.html
+++ b/src/views/bankrupt_officer.html
@@ -54,6 +54,12 @@
       </dt>
       <dd class="govuk-summary-list__value">{{ bankruptOfficer.dateOfBirth }}</dd>
     </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Debtor Discharge Date
+      </dt>
+      <dd class="govuk-summary-list__value">{{ bankruptOfficer.debtorDischargeDate }}</dd>
+    </div>
   </dl>
   <h2 class="govuk-heading-m">Address details</h2>
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
@@ -120,14 +126,6 @@
       <dd class="govuk-summary-list__value">{{ bankruptOfficer.startDate }}</dd>
     </div>
   </dl>
-  <h2 class="govuk-heading-m">Discharge dates</h2>
-  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Debtor discharge date
-      </dt>
-      <dd class="govuk-summary-list__value">{{ bankruptOfficer.debtorDischargeDate }}</dd>
-    </div>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
         Trustee discharge date


### PR DESCRIPTION
Resolves: [BI-11924](https://companieshouse.atlassian.net/browse/BI-11924) and [BI-11926](https://companieshouse.atlassian.net/browse/BI-11926)

Adding `debtorDschargeDate` field to the Results page, moving the position of Discharge Dates section to appear underneath the personal details section. 