### PR TITLE
BI-6621 Add Pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2832,9 +2832,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.10.2.tgz",
-      "integrity": "sha512-MpMymgLsKoMw40MggZ0XLCAj1FY5N2s8Pf3aQR+k0cZOsegjLsnejxNfEB9qEl9jcma2fiiVcvsEZ+Ipo+Oo2g=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.1.tgz",
+      "integrity": "sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A=="
     },
     "graceful-fs": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "axios": "^0.24.0",
     "cookie-parser": "^1.4.5",
     "express": "^4.17.1",
-    "govuk-frontend": "^3.10.1",
+    "govuk-frontend": "^4.3.1",
     "helmet": "^4.2.0",
     "ioredis": "^4.19.4",
     "moment": "^2.29.1",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -39,3 +39,5 @@ export const ADD_TO_FRONT: string = "add_to_front";
 export const ADD_TO_END: string = "add_to_end";
 export const ADD_ELLIPSIS: string = "add_ellipsis";
 export const RESULTS_PER_PAGE: number = Number(getEnvironmentValueOrDefault("RESULTS_PER_PAGE", "20"));
+export const BANKRUPT_OFFICER_SEARCH_SESSION: string = "bankrupt-officer-search-session";
+export const SESSION_FILTER = "filters";

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,6 +8,16 @@ export const getEnvironmentValue = (key: string): string => {
   return value;
 };
 
+export const getEnvironmentValueOrDefault = (key: string, defaultValue: any): string => {
+  const value: string = process.env[key] || "";
+
+  if (!value) {
+    return defaultValue;
+  }
+
+  return value;
+};
+
 export const CDN_HOST = getEnvironmentValue("CDN_HOST");
 export const PIWIK_URL = getEnvironmentValue("PIWIK_URL");
 export const PIWIK_SITE_ID = getEnvironmentValue("PIWIK_SITE_ID");
@@ -23,3 +33,9 @@ export const SCOTTISH_BANKRUPT_OFFICER = "/admin/officer-search/scottish-bankrup
 export const SCOTTISH_BANKRUPT_OFFICER_DETAILS = "/admin/officer-search/scottish-bankrupt-officer/:id";
 
 export const PERMISSIONS_PATH = SCOTTISH_BANKRUPT_OFFICER;
+
+// For pagination component
+export const ADD_TO_FRONT: string = "add_to_front";
+export const ADD_TO_END: string = "add_to_end";
+export const ADD_ELLIPSIS: string = "add_ellipsis";
+export const RESULTS_PER_PAGE: number = Number(getEnvironmentValueOrDefault("RESULTS_PER_PAGE", "20"));

--- a/src/controller/bankrupt/bankrupt.controller.ts
+++ b/src/controller/bankrupt/bankrupt.controller.ts
@@ -2,17 +2,14 @@ import { NextFunction, Request, Response } from 'express';
 
 import { logger, formattingOfficersInfo, userSession, buildPaginationData } from '../../utils';
 import { fetchBankruptOfficers } from '../../service';
-import { BankruptOfficerSearchFilters, BankruptOfficerSearchQuery } from '../../types';
-import { RESULTS_PER_PAGE } from '../../config';
+import { BankruptOfficerSearchFilters, BankruptOfficerSearchQuery, BankruptOfficerSearchSessionExtraData } from '../../types';
+import { BANKRUPT_OFFICER_SEARCH_SESSION, RESULTS_PER_PAGE, SCOTTISH_BANKRUPT_OFFICER } from '../../config';
 
 export const getSearchPage = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
-    if (req.query.page) {
-      // Search has already been done, get filters from cache, fetch the correct page and render
-      const filters: BankruptOfficerSearchFilters | undefined = req.session?.getExtraData("bados-filters");
-      if (filters) {
-        return await renderSearchResultsPage(req, res, filters);
-      }
+    const sessionExtraData: undefined | BankruptOfficerSearchSessionExtraData = req.session?.getExtraData(BANKRUPT_OFFICER_SEARCH_SESSION);
+    if (req.query.page && sessionExtraData?.filters) {
+      return await renderSearchResultsPage(req, res, sessionExtraData.filters);
     } 
     const userEmail = userSession.getLoggedInUserEmail(req.session);
     res.render('bankrupt', { userEmail });
@@ -32,9 +29,12 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
       (req.body["dob-dd"] && req.body["dob-mm"] && req.body["dob-yyyy"]) ?
         `${req.body["dob-yyyy"]}-${req.body["dob-mm"]}-${req.body["dob-dd"]}` : '';
 
-    // Set post query data
     const filters: BankruptOfficerSearchFilters = { forename1, surname, dateOfBirth, postcode };
-    req.session?.setExtraData("bados-filters", filters);
+
+    let sessionExtraData: undefined | BankruptOfficerSearchSessionExtraData = req.session?.getExtraData(BANKRUPT_OFFICER_SEARCH_SESSION);
+    sessionExtraData = {...sessionExtraData, filters};
+    req.session?.setExtraData(BANKRUPT_OFFICER_SEARCH_SESSION, sessionExtraData);
+
     return await renderSearchResultsPage(req, res, filters);
   } catch (err) {
     logger.error(`${err}`);
@@ -44,18 +44,19 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
 
 const renderSearchResultsPage = async (req: Request, res: Response, filters: BankruptOfficerSearchFilters) => {
   const body: BankruptOfficerSearchQuery = { startIndex: req.query.page ? Number(req.query.page) - 1 : 0, itemsPerPage: RESULTS_PER_PAGE, filters};
-  //const results = await fetchBankruptOfficers(req.session, body);
-  const results = testData;
-  results.resource.startIndex = req.query.page ? Number(req.query.page) - 1 : 0;
+
+  const results = await fetchBankruptOfficers(req.session, body);
   // Not found officers has to be rendered anyway with an empty list 
   if(results.httpStatusCode === 404  || results.httpStatusCode === 200){
     const userEmail = userSession.getLoggedInUserEmail(req.session);
-    const paginationData = buildPaginationData(results);
     const { itemsPerPage = 0, startIndex = 0, totalResults = 0, items = [] } = results.resource || {};
+    let paginationData;
+    if (totalResults > 0 && itemsPerPage > 0) {
+      const numOfPages = Math.ceil(totalResults / RESULTS_PER_PAGE);
+      paginationData = buildPaginationData(startIndex + 1, numOfPages, SCOTTISH_BANKRUPT_OFFICER);
+    }
     return res.render('bankrupt', { pagination: paginationData, itemsPerPage, startIndex, totalResults, items: formattingOfficersInfo(items), searched: true, userEmail });
   } else {
     return res.status(results.httpStatusCode).render('error-pages/500');
   } 
 }
-
-const testData = {"httpStatusCode":200,"resource":{"itemsPerPage":10,"startIndex":0,"totalResults":40,"items":[{"ephemeralKey":"BC13AB4C5AED334CE05400144FFBDD12","forename1":"DROPLUMINOUS","forename2":"TIGERCLEVER","surname":"PLAYERLUMINOUS","addressLine1":"HIGH AVENUE","town":"LUCIEN","county":"KENT","postcode":"KX3 3FR","dateOfBirth":"1955-04-15"},{"ephemeralKey":"BC13AB4C5AEE334CE05400144FFBDD12","forename1":"TALONHAZEL","forename2":"TIGERPEWTER","surname":"WOLFDEW","addressLine1":"FRIARS COURT","town":"BALDOCK","postcode":"AB0 2IH","dateOfBirth":"1995-08-26"},{"ephemeralKey":"BC13AB4C5AEF334CE05400144FFBDD12","forename1":"HORSEQUIVER","surname":"RACERCHISEL","addressLine1":"FRIARS PARK","postcode":"AR2 7PR"},{"ephemeralKey":"BC13AB4C5AF0334CE05400144FFBDD12","forename1":"SLICERVOLCANO","surname":"SPURBALLISTIC","addressLine1":"WOOD STREET","town":"CAMPDEN","postcode":"SH0 3GY","dateOfBirth":"1977-11-22"},{"ephemeralKey":"BC13AB4C5AF1334CE05400144FFBDD12","forename1":"FLAMEMETAL","surname":"ANTLERSPONGE","addressLine1":"CHURCH WALK","town":"CAMPDEN","postcode":"VT0 3UH","dateOfBirth":"1955-05-10"},{"ephemeralKey":"BC13AB4C5AF2334CE05400144FFBDD12","forename1":"STALKERHOLLOW","surname":"GRASPWELL","addressLine1":"CHURCH WALK","town":"BUFFALO CITY","county":"BEDFORDSHIRE","postcode":"NM4 2FA","dateOfBirth":"1978-12-29"},{"ephemeralKey":"BC13AB4C5AF3334CE05400144FFBDD12","forename1":"GOATBRANCH","surname":"GRINSHARP","addressLine1":"WOOD CLOSE","town":"CIENEGA SPRINGS","county":"WARWICKSHIRE","postcode":"NJ6 6JO","dateOfBirth":"1945-09-20"},{"ephemeralKey":"BC13AB4C5AF4334CE05400144FFBDD12","forename1":"HOOFOASIS","forename2":"SAGEPITCH","surname":"KNIGHTLIGHTNING","addressLine1":"HILL CRESCENT","town":"RANSOM CANYON","postcode":"YB3 0KB","dateOfBirth":"1990-11-21"},{"ephemeralKey":"BC13AB4C5AF5334CE05400144FFBDD12","forename1":"GLAZERPRAIRIE","surname":"SALMONFOAM","addressLine1":"HILL CLOSE","town":"NEWSTEAD","postcode":"KK2 4BS","dateOfBirth":"1996-06-05"},{"ephemeralKey":"BC13AB4C5AF6334CE05400144FFBDD12","forename1":"PIPERFIRE","forename2":"WOLVERINENETTLE","surname":"EATERBLACK","addressLine1":"DICKINSON CRESCENT","town":"BALDOCK","county":"BERKSHIRE","postcode":"OP2 8FU","dateOfBirth":"1971-09-11"}]}}

--- a/src/controller/bankrupt/bankrupt.controller.ts
+++ b/src/controller/bankrupt/bankrupt.controller.ts
@@ -1,11 +1,19 @@
 import { NextFunction, Request, Response } from 'express';
 
-import { logger, formattingOfficersInfo, userSession } from '../../utils';
+import { logger, formattingOfficersInfo, userSession, buildPaginationData } from '../../utils';
 import { fetchBankruptOfficers } from '../../service';
 import { BankruptOfficerSearchFilters, BankruptOfficerSearchQuery } from '../../types';
+import { RESULTS_PER_PAGE } from '../../config';
 
-export const getSearchPage = (req: Request, res: Response, next: NextFunction): void => {
+export const getSearchPage = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
+    if (req.query.page) {
+      // Search has already been done, get filters from cache, fetch the correct page and render
+      const filters: BankruptOfficerSearchFilters | undefined = req.session?.getExtraData("bados-filters");
+      if (filters) {
+        return await renderSearchResultsPage(req, res, filters);
+      }
+    } 
     const userEmail = userSession.getLoggedInUserEmail(req.session);
     res.render('bankrupt', { userEmail });
   } catch (err) {
@@ -26,20 +34,28 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
 
     // Set post query data
     const filters: BankruptOfficerSearchFilters = { forename1, surname, dateOfBirth, postcode };
-    const body: BankruptOfficerSearchQuery = { startIndex: 0, itemsPerPage: 10, filters};
-
-    const results = await fetchBankruptOfficers(req.session, body);
-    // Not found officers has to be rendered anyway with an empty list 
-    if(results.httpStatusCode === 404  || results.httpStatusCode === 200){
-      const userEmail = userSession.getLoggedInUserEmail(req.session);
-      const { itemsPerPage = 0, startIndex = 0, totalResults = 0, items = [] } = results.resource || {};
-      return res.render('bankrupt', { itemsPerPage, startIndex, totalResults, items: formattingOfficersInfo(items), searched: true, userEmail });
-    } else {
-      return res.status(results.httpStatusCode).render('error-pages/500');
-    } 
-
+    req.session?.setExtraData("bados-filters", filters);
+    return await renderSearchResultsPage(req, res, filters);
   } catch (err) {
     logger.error(`${err}`);
     next(err);
   }
 };
+
+const renderSearchResultsPage = async (req: Request, res: Response, filters: BankruptOfficerSearchFilters) => {
+  const body: BankruptOfficerSearchQuery = { startIndex: req.query.page ? Number(req.query.page) - 1 : 0, itemsPerPage: RESULTS_PER_PAGE, filters};
+  //const results = await fetchBankruptOfficers(req.session, body);
+  const results = testData;
+  results.resource.startIndex = req.query.page ? Number(req.query.page) - 1 : 0;
+  // Not found officers has to be rendered anyway with an empty list 
+  if(results.httpStatusCode === 404  || results.httpStatusCode === 200){
+    const userEmail = userSession.getLoggedInUserEmail(req.session);
+    const paginationData = buildPaginationData(results);
+    const { itemsPerPage = 0, startIndex = 0, totalResults = 0, items = [] } = results.resource || {};
+    return res.render('bankrupt', { pagination: paginationData, itemsPerPage, startIndex, totalResults, items: formattingOfficersInfo(items), searched: true, userEmail });
+  } else {
+    return res.status(results.httpStatusCode).render('error-pages/500');
+  } 
+}
+
+const testData = {"httpStatusCode":200,"resource":{"itemsPerPage":10,"startIndex":0,"totalResults":40,"items":[{"ephemeralKey":"BC13AB4C5AED334CE05400144FFBDD12","forename1":"DROPLUMINOUS","forename2":"TIGERCLEVER","surname":"PLAYERLUMINOUS","addressLine1":"HIGH AVENUE","town":"LUCIEN","county":"KENT","postcode":"KX3 3FR","dateOfBirth":"1955-04-15"},{"ephemeralKey":"BC13AB4C5AEE334CE05400144FFBDD12","forename1":"TALONHAZEL","forename2":"TIGERPEWTER","surname":"WOLFDEW","addressLine1":"FRIARS COURT","town":"BALDOCK","postcode":"AB0 2IH","dateOfBirth":"1995-08-26"},{"ephemeralKey":"BC13AB4C5AEF334CE05400144FFBDD12","forename1":"HORSEQUIVER","surname":"RACERCHISEL","addressLine1":"FRIARS PARK","postcode":"AR2 7PR"},{"ephemeralKey":"BC13AB4C5AF0334CE05400144FFBDD12","forename1":"SLICERVOLCANO","surname":"SPURBALLISTIC","addressLine1":"WOOD STREET","town":"CAMPDEN","postcode":"SH0 3GY","dateOfBirth":"1977-11-22"},{"ephemeralKey":"BC13AB4C5AF1334CE05400144FFBDD12","forename1":"FLAMEMETAL","surname":"ANTLERSPONGE","addressLine1":"CHURCH WALK","town":"CAMPDEN","postcode":"VT0 3UH","dateOfBirth":"1955-05-10"},{"ephemeralKey":"BC13AB4C5AF2334CE05400144FFBDD12","forename1":"STALKERHOLLOW","surname":"GRASPWELL","addressLine1":"CHURCH WALK","town":"BUFFALO CITY","county":"BEDFORDSHIRE","postcode":"NM4 2FA","dateOfBirth":"1978-12-29"},{"ephemeralKey":"BC13AB4C5AF3334CE05400144FFBDD12","forename1":"GOATBRANCH","surname":"GRINSHARP","addressLine1":"WOOD CLOSE","town":"CIENEGA SPRINGS","county":"WARWICKSHIRE","postcode":"NJ6 6JO","dateOfBirth":"1945-09-20"},{"ephemeralKey":"BC13AB4C5AF4334CE05400144FFBDD12","forename1":"HOOFOASIS","forename2":"SAGEPITCH","surname":"KNIGHTLIGHTNING","addressLine1":"HILL CRESCENT","town":"RANSOM CANYON","postcode":"YB3 0KB","dateOfBirth":"1990-11-21"},{"ephemeralKey":"BC13AB4C5AF5334CE05400144FFBDD12","forename1":"GLAZERPRAIRIE","surname":"SALMONFOAM","addressLine1":"HILL CLOSE","town":"NEWSTEAD","postcode":"KK2 4BS","dateOfBirth":"1996-06-05"},{"ephemeralKey":"BC13AB4C5AF6334CE05400144FFBDD12","forename1":"PIPERFIRE","forename2":"WOLVERINENETTLE","surname":"EATERBLACK","addressLine1":"DICKINSON CRESCENT","town":"BALDOCK","county":"BERKSHIRE","postcode":"OP2 8FU","dateOfBirth":"1971-09-11"}]}}

--- a/src/controller/bankrupt/bankrupt.controller.ts
+++ b/src/controller/bankrupt/bankrupt.controller.ts
@@ -8,7 +8,7 @@ import { BANKRUPT_OFFICER_SEARCH_SESSION, RESULTS_PER_PAGE, SCOTTISH_BANKRUPT_OF
 export const getSearchPage = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const sessionExtraData: undefined | BankruptOfficerSearchSessionExtraData = req.session?.getExtraData(BANKRUPT_OFFICER_SEARCH_SESSION);
-    if (req.query.page && sessionExtraData?.filters) {
+    if (req.query?.page && sessionExtraData?.filters) {
       return await renderSearchResultsPage(req, res, sessionExtraData.filters);
     } 
     const userEmail = userSession.getLoggedInUserEmail(req.session);
@@ -43,7 +43,7 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
 };
 
 const renderSearchResultsPage = async (req: Request, res: Response, filters: BankruptOfficerSearchFilters) => {
-  const body: BankruptOfficerSearchQuery = { startIndex: req.query.page ? Number(req.query.page) - 1 : 0, itemsPerPage: RESULTS_PER_PAGE, filters};
+  const body: BankruptOfficerSearchQuery = { startIndex: req.query?.page ? Number(req.query.page) - 1 : 0, itemsPerPage: RESULTS_PER_PAGE, filters};
 
   const results = await fetchBankruptOfficers(req.session, body);
   // Not found officers has to be rendered anyway with an empty list 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,3 +41,20 @@ export interface BankruptOfficerSearchResults {
   totalResults: number
   items: BankruptOfficer[]
 }
+
+export interface PaginationData {
+  previous?: PaginationPreviousNext,
+  next?: PaginationPreviousNext,
+  items: PageItem[]
+}
+
+export interface PaginationPreviousNext {
+  href: string
+}
+
+export interface PageItem {
+  number?: number,
+  href?: string,
+  current?: boolean,
+  ellipsis?: boolean
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import { SESSION_FILTER } from "../config";
+
 export interface Address {
   addressLine1?: string
   addressLine2?: string
@@ -57,4 +59,8 @@ export interface PageItem {
   href?: string,
   current?: boolean,
   ellipsis?: boolean
+}
+
+export interface BankruptOfficerSearchSessionExtraData {
+  [SESSION_FILTER]?: BankruptOfficerSearchFilters
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,3 +12,8 @@ export * as userSession from "./session/session";
  *
  */
 export { formattingOfficersInfo } from "./script/formatting";
+
+/**
+ *
+ */
+ export { buildPaginationData } from "./pagination/pagination";

--- a/src/utils/pagination/pagination.ts
+++ b/src/utils/pagination/pagination.ts
@@ -1,0 +1,83 @@
+import { BankruptOfficerSearchResults, PageItem, PaginationData } from '../../types';
+import { SCOTTISH_BANKRUPT_OFFICER, ADD_TO_FRONT, ADD_TO_END, RESULTS_PER_PAGE } from '../../config';
+import { Resource } from "api-sdk-node";
+import { logger } from '../../utils';
+
+const addPageItem = (items: PageItem[], pageNumber: number, operation: string, current: boolean) => {
+  let page: PageItem;
+  page = {
+    number: pageNumber,
+    href: `${SCOTTISH_BANKRUPT_OFFICER}?page=${pageNumber}`, 
+  }
+  if (current) page.current = true;
+  switch (operation) {
+    case ADD_TO_FRONT: items.unshift(page); break;
+    case ADD_TO_END: items.push(page); break;
+    default: logger.info("Pagination: Unidentified operation during addPageItem: " + operation);
+  }
+}
+
+const buildLeftSide = (paginationData: PageItem[], actualPage: number) => {
+  let pagesAdded = 0;
+  let currentPage = actualPage - 1;
+  while (pagesAdded < 2 && currentPage >= 1) {
+    addPageItem(paginationData, currentPage, ADD_TO_FRONT, false);
+    currentPage--;
+    pagesAdded++;
+  }
+  if (currentPage === 1) {
+    addPageItem(paginationData, currentPage, ADD_TO_FRONT, false);
+  }
+  if (paginationData[0].number !== 1) {
+    paginationData.unshift({
+      ellipsis: true
+    })
+    addPageItem(paginationData, 1, ADD_TO_FRONT, false);
+  }
+}
+
+const buildRightSide = (paginationData: PageItem[], actualPage: number, numOfPages: number) => {
+  let pagesAdded = 0;
+  let currentPage = actualPage + 1;
+  while (pagesAdded < 2 && currentPage <= numOfPages) {
+    addPageItem(paginationData, currentPage, ADD_TO_END, false);
+    currentPage++;
+    pagesAdded++;
+  }
+  if (currentPage === numOfPages) {
+    addPageItem(paginationData, currentPage, ADD_TO_END, false);
+  }
+  if (paginationData[paginationData.length-1].number !== numOfPages) {
+    paginationData.push({
+      ellipsis: true
+    })
+    addPageItem(paginationData, numOfPages, ADD_TO_END, false);
+  }
+}
+
+export const buildPaginationData = (searchResults: Resource<BankruptOfficerSearchResults>): PaginationData =>  {
+  const {startIndex = 0, totalResults = 0, itemsPerPage = 0} = searchResults.resource || {};
+          
+  const pagination: PaginationData = {items: []}; 
+  const actualPage = startIndex + 1; // index starts at 0 so need to add 1 to get the actual page number
+  const paginationData: PageItem[] = [];
+
+  const numOfPages = Math.ceil(totalResults / itemsPerPage);
+  if (actualPage !== 1) pagination.previous = {href: `${SCOTTISH_BANKRUPT_OFFICER}?page=${actualPage-1}`}
+  if (actualPage !== numOfPages) pagination.next = {href: `${SCOTTISH_BANKRUPT_OFFICER}?page=${actualPage+1}`}
+
+  // If there are less than 8 pages, just display all the links
+  if (numOfPages < 8) {
+    for (let i = 0; i<numOfPages; i++) {
+      const pageNumber: number = i + 1;
+      const current = pageNumber === actualPage;
+      addPageItem(paginationData, pageNumber, ADD_TO_END, current);
+    }
+  } else {
+    addPageItem(paginationData, actualPage, ADD_TO_END, true);
+    buildLeftSide(paginationData, actualPage);
+    buildRightSide(paginationData, actualPage, numOfPages);
+  }
+  pagination.items = paginationData;
+  return pagination;
+}

--- a/src/views/bankrupt.html
+++ b/src/views/bankrupt.html
@@ -75,7 +75,6 @@
 {% if searched %}
   <h2 class="govuk-heading-l">Search results</h2>
   <span id="results-hint" class="govuk-hint">
-    <!--Showing {{ itemsPerPage + startIndex }} of {{ totalResults }} results-->
     Showing {{ itemsPerPage }} of {{ totalResults }} results
   </span>
   <div class="govuk-grid-column-full-width">
@@ -103,7 +102,9 @@
       <h2 class="govuk-heading-s">No results found matching your search criteria.</h2>
     {% endif %}
     {% if pagination %}
+    <div id="pagination-container">
       {{ govukPagination(pagination) }}
+    </div>
     {% endif %}
   </div>   
 {% endif %}

--- a/src/views/bankrupt.html
+++ b/src/views/bankrupt.html
@@ -70,16 +70,16 @@
   <button class="govuk-button" data-module="govuk-button">
     Search
   </button>
-
 </form>
 
 {% if searched %}
   <h2 class="govuk-heading-l">Search results</h2>
   <span id="results-hint" class="govuk-hint">
-    Showing {{ itemsPerPage + startIndex }} of {{ totalResults }} results
+    <!--Showing {{ itemsPerPage + startIndex }} of {{ totalResults }} results-->
+    Showing {{ itemsPerPage }} of {{ totalResults }} results
   </span>
   <div class="govuk-grid-column-full-width">
-    <table class="govuk-table">
+    <table id="results-table" class="govuk-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">First name</th>
@@ -102,7 +102,10 @@
     {% if not items or not items|length %}
       <h2 class="govuk-heading-s">No results found matching your search criteria.</h2>
     {% endif %}
-  </div>
+    {% if pagination %}
+      {{ govukPagination(pagination) }}
+    {% endif %}
+  </div>   
 {% endif %}
 
 {% endblock %}

--- a/src/views/layout.html
+++ b/src/views/layout.html
@@ -15,10 +15,12 @@
 {% from "./components/header/macro.njk"               import chHeader %}
 {% from "./components/footer/macro.njk"               import chFooter %}
 {% from "govuk/components/table/macro.njk"            import govukTable %}
+{% from "govuk/components/pagination/macro.njk"       import govukPagination %}
 
 {% block head %}
 <meta name="format-detection" content="telephone=no">
 <!--[if !IE 8]><!-->
+<link rel="stylesheet" type="text/css" media="all" href="//{{CDN_HOST}}/stylesheets/govuk-frontend/v4.3.1/govuk-frontend-4.3.1.min.css" />
 <link rel="stylesheet" type="text/css" media="all" href="//{{CDN_HOST}}/stylesheets/services/bankrupt-officers/app.min.css" />
 <link rel="stylesheet" type="text/css" media="all" href="//{{CDN_HOST}}/stylesheets/services/bankrupt-officers/footer.min.css" />
 <!--<![endif]-->
@@ -83,6 +85,7 @@
     (function() {
       bindPiwikListener('bankruptcy', '{{PIWIK_URL}}', {{PIWIK_SITE_ID}});
     }());
+    location.href = "#results-table";
   </script>
   <noscript>
     <p>

--- a/test/__mocks__/utils.mock.ts
+++ b/test/__mocks__/utils.mock.ts
@@ -63,6 +63,18 @@ export const BANKRUPT_OFFICER_SEARCH_NO_PAGE_RESULTS = {
   items: []
 };
 
+export const PAGINATION_RESULTS = {
+  pagination: {
+    items: [
+      {
+        current: true,
+        href: "/admin/officer-search/scottish-bankrupt-officer?page=1",
+        number: 1
+      }
+    ]
+  }
+}
+
 export const errorStatusCode = [401, 404, 500];
 
 export const mockPostResponse = { 

--- a/test/controller/bankrupt.spec.ts
+++ b/test/controller/bankrupt.spec.ts
@@ -11,7 +11,8 @@ import {
   BANKRUPT_OFFICER_SEARCH_NO_PAGE_RESULTS,
   BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS,
   mockPostResponse,
-  mockSearchQuery
+  mockSearchQuery,
+  PAGINATION_RESULTS
 } from '../__mocks__/utils.mock';
 
 import { getSessionRequest } from '../__mocks__/session.mock';
@@ -82,7 +83,7 @@ describe("BankruptController test suite", () => {
       await postSearchPage(req, res, nextFunctionSpy);
 
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { searched: true, ...BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS, userEmail: "test@testemail.com"  });
+      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { searched: true, ...BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS, ...PAGINATION_RESULTS, userEmail: "test@testemail.com"  });
     });
 
     it("should renders the bankrupt officer search page with the list of officers considering the DAB", async () => {
@@ -94,7 +95,7 @@ describe("BankruptController test suite", () => {
       await postSearchPage(req, res, nextFunctionSpy);
 
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { searched: true, ...BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS, userEmail: "test@testemail.com" });
+      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { searched: true, ...BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS, ...PAGINATION_RESULTS, userEmail: "test@testemail.com" });
     });
 
     it("should renders the bankrupt officer search page with not officers", async () => {
@@ -105,7 +106,7 @@ describe("BankruptController test suite", () => {
       await postSearchPage(req, res, nextFunctionSpy);
 
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { searched: true, ...BANKRUPT_OFFICER_SEARCH_NO_PAGE_RESULTS, userEmail: "test@testemail.com" });
+      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { searched: true, ...BANKRUPT_OFFICER_SEARCH_NO_PAGE_RESULTS, pagination: undefined, userEmail: "test@testemail.com" });
     });
 
     it('should return none data with status code 500 and render error-pages/500 page', async () => {

--- a/test/utils/pagination.spec.ts
+++ b/test/utils/pagination.spec.ts
@@ -1,0 +1,89 @@
+import { buildPaginationData } from "../../src/utils";
+import { expect } from 'chai';
+
+describe('Pagination test suite', () => {
+  const prefix = "prefix";
+
+  it('Should not add ellipses when the number of pages is less than 9', () => {
+    const numOfPages = 4;
+    const currentPage = 2;
+    const paginationData = buildPaginationData(currentPage, numOfPages, prefix);
+    const expectedData = {
+      "items":[
+        {"number":1,"href":"prefix?page=1"},
+        {"number":2,"href":"prefix?page=2","current":true},
+        {"number":3,"href":"prefix?page=3"},
+        {"number":4,"href":"prefix?page=4"}
+      ],
+      "previous":{"href":"prefix?page=1"},
+      "next":{"href":"prefix?page=3"}
+    }
+    expect(paginationData).to.deep.equal(expectedData);
+  });
+
+  it('Should add an ellipsis in the end when the number of pages is 9 or larger and the current page is < 5', () => {
+    const numOfPages = 10;
+    const currentPage = 4;
+    const paginationData = buildPaginationData(currentPage, numOfPages, prefix);
+    const expectedData = {
+      "items":[
+        {"number":1,"href":"prefix?page=1"},
+        {"number":2,"href":"prefix?page=2"},
+        {"number":3,"href":"prefix?page=3"},
+        {"number":4,"href":"prefix?page=4","current":true},
+        {"number":5,"href":"prefix?page=5"},
+        {"number":6,"href":"prefix?page=6"},
+        {"number":7,"href":"prefix?page=7"},
+        {"number":8,"href":"prefix?page=8"},
+        {"ellipsis":true},
+        {"number":10,"href":"prefix?page=10"}
+      ],
+      "previous":{"href":"prefix?page=3"},
+      "next":{"href":"prefix?page=5"}
+    }
+    expect(paginationData).to.deep.equal(expectedData);
+  });
+
+  it('Should add an ellipsis at the front when the number of pages is 9 or larger and the difference between the last page and the current page is < 5', () => {
+    const numOfPages = 10;
+    const currentPage = 7;
+    const paginationData = buildPaginationData(currentPage, numOfPages, prefix);
+    const expectedData = {
+      "items":[
+        {"number":1,"href":"prefix?page=1"},
+        {"ellipsis":true},
+        {"number":4,"href":"prefix?page=4"},
+        {"number":5,"href":"prefix?page=5"},
+        {"number":6,"href":"prefix?page=6"},
+        {"number":7,"href":"prefix?page=7","current":true},
+        {"number":8,"href":"prefix?page=8"},
+        {"number":9,"href":"prefix?page=9"},
+        {"number":10,"href":"prefix?page=10"}
+      ],
+      "previous":{"href":"prefix?page=6"},
+      "next":{"href":"prefix?page=8"}
+    }
+    expect(paginationData).to.deep.equal(expectedData);
+  });
+
+  it('Should add ellipses at both sides when the number of pages > 9 and the current page is around the middle', () => {
+    const numOfPages = 11;
+    const currentPage = 6;
+    const paginationData = buildPaginationData(currentPage, numOfPages, prefix);
+    const expectedData = {
+      "items":[
+        {"number":1,"href":"prefix?page=1"},
+        {"ellipsis":true},
+        {"number":4,"href":"prefix?page=4"},
+        {"number":5,"href":"prefix?page=5"},
+        {"number":6,"href":"prefix?page=6","current":true},
+        {"number":7,"href":"prefix?page=7"},
+        {"number":8,"href":"prefix?page=8"},
+        {"ellipsis":true},
+        {"number":11,"href":"prefix?page=11"}
+      ],
+      "previous":{"href":"prefix?page=5"},
+      "next":{"href":"prefix?page=7"}}
+    expect(paginationData).to.deep.equal(expectedData);
+  });
+});

--- a/test/utils/pagination.spec.ts
+++ b/test/utils/pagination.spec.ts
@@ -21,7 +21,7 @@ describe('Pagination test suite', () => {
     expect(paginationData).to.deep.equal(expectedData);
   });
 
-  it('Should add an ellipsis in the end when the number of pages is 9 or larger and the current page is < 5', () => {
+  it('Should add an ellipsis in the end when the number of pages is 9 or larger and the current page is <= 5', () => {
     const numOfPages = 10;
     const currentPage = 4;
     const paginationData = buildPaginationData(currentPage, numOfPages, prefix);
@@ -44,7 +44,7 @@ describe('Pagination test suite', () => {
     expect(paginationData).to.deep.equal(expectedData);
   });
 
-  it('Should add an ellipsis at the front when the number of pages is 9 or larger and the difference between the last page and the current page is < 5', () => {
+  it('Should add an ellipsis at the front when the number of pages is 9 or larger and the difference between the last page and the current page is <= 4', () => {
     const numOfPages = 10;
     const currentPage = 7;
     const paginationData = buildPaginationData(currentPage, numOfPages, prefix);


### PR DESCRIPTION
Resolves [BI-6621](https://companieshouse.atlassian.net/browse/BI-6621)

Add pagination feature to the search results page:

- Uses the Pagination component from govuk-frontend
- Always includes links to the first and last pages
- Adds ellipses to between skipped pages
- Automatically scrolls to the results table upon completing search