### PR TITLE
Amend DOB format validation to accept dd/mm/yyyy as well as d/m/yyyy

### DIFF
--- a/src/utils/validation/validation.ts
+++ b/src/utils/validation/validation.ts
@@ -4,9 +4,9 @@ import moment from 'moment';
 const now = moment();
 
 export function isValidDate(input: moment.MomentInput): boolean | undefined {
-
+  const minDate = moment.utc("0001-01-01");
   if(input !== ''){
-    return  moment(input, 'YYYY-M-D', true).isValid();
+    return moment(input, 'YYYY-M-D', true).isValid() && (moment(input, 'YYYY-M-D').isAfter(minDate));
   }
 }
   

--- a/src/utils/validation/validation.ts
+++ b/src/utils/validation/validation.ts
@@ -6,7 +6,7 @@ const now = moment();
 export function isValidDate(input: moment.MomentInput): boolean | undefined {
 
   if(input !== ''){
-    return  moment(input, 'YYYY-MM-DD', true).isValid();
+    return  moment(input, 'YYYY-M-D', true).isValid();
   }
 }
   

--- a/src/views/bankrupt.html
+++ b/src/views/bankrupt.html
@@ -69,7 +69,7 @@
             Enter a Date of Birth or a Last Name
           </label>>
           {% elif whereTo === 'invalidFromDob' %}
-          <label class="govuk-error-message">
+          <label class="govuk-error-message" id="invalid-from-dob-error">
             Enter a valid date
           </label>
         {% endif %}
@@ -116,7 +116,7 @@
               Enter a Date of Birth or a Last Name
             </label>>
            {% elif toDobError === 'invalidToDob' %}
-           <label class="govuk-error-message">
+           <label class="govuk-error-message" id="invalid-to-dob-error">
             Enter a valid date
           </label>
            {% endif %}

--- a/src/views/bankrupt.html
+++ b/src/views/bankrupt.html
@@ -110,15 +110,16 @@
           <div id="dob-hint" class="govuk-hint">
             For example, 31 03 1985
           </div>
+          <div class="govuk-date-input" id="to-dob">
              {% if whereTo === 'noInfo' %}
             <label class="govuk-error-message">
               Enter a Date of Birth or a Last Name
+            </label>>
            {% elif toDobError === 'invalidToDob' %}
            <label class="govuk-error-message">
             Enter a valid date
           </label>
            {% endif %}
-          <div class="govuk-date-input" id="to-dob">
             <div class="govuk-date-input__item">
               <div class="govuk-form-group">
                 <label class="govuk-label govuk-date-input__label" for="to-dob-day">


### PR DESCRIPTION
Fix for issue found in [BI-6425](https://companieshouse.atlassian.net/browse/BI-6425)

- Amend date format validation to accept `dd/mm/yyyy` as well as `d/m/yyyy` formats to avoid throwing error when single digit dates are entered by user. 
- Adding missing label tag to increase spacing when mandatory error is thrown for name/dob error