### PR TITLE
Show errors on both dates if they are from the future

### DIFF
--- a/src/controller/bankrupt/bankrupt.controller.ts
+++ b/src/controller/bankrupt/bankrupt.controller.ts
@@ -69,6 +69,11 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
       validationErrors.push(new ValidationError('invalidToDob', 'Enter a valid date'));
       toDobError = "invalidToDob";
     }
+    
+    if (filters.fromDateOfBirth === '' && filters.toDateOfBirth === '' && filters.surname === '') {
+      validationErrors.push(new ValidationError('noInfo', 'Enter a Date Of Birth or Last Name'));
+      whereTo = "noInfo";
+    }
 
     if (validationErrors.length > 0) {
       const validationResult = new ValidationResult(validationErrors);
@@ -79,16 +84,6 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
         ...(toDobError && { toDobError })
       }
       return res.render('bankrupt', templateVariables);
-    }
-    
-    if (filters.fromDateOfBirth === '' && filters.toDateOfBirth === '' && filters.surname === '') {
-      validationErrors.push(new ValidationError('noInfo', 'Enter a Date Of Birth or Last Name'));
-      whereTo = "noInfo";
-    }
-
-    if (validationErrors.length > 0) {
-      const validationResult = new ValidationResult(validationErrors);
-      return res.render('bankrupt', { userEmail, validationResult, whereTo});
     }
 
     return await renderSearchResultsPage(req, res, filters);

--- a/test/controller/bankrupt.spec.ts
+++ b/test/controller/bankrupt.spec.ts
@@ -171,7 +171,7 @@ describe("BankruptController test suite", () => {
       await postSearchPage(req, res, nextFunctionSpy);
 
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { whereTo: undefined, validationResult, userEmail: "test@testemail.com" });
+      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { validationResult, userEmail: "test@testemail.com" });
     });
 
     it("should renders the bankrupt officer search page with errors when no filters are used", async () => {
@@ -256,7 +256,10 @@ describe("BankruptController test suite", () => {
       req.body = mockSearchQueryInvalidToAndFromDob.filters;
       sinon.stub(BadosService.prototype, 'getBankruptOfficers').rejects(mockPostResponse[404]);
       sinon.stub(userSession, "getLoggedInUserEmail").returns('test@testemail.com');
-      const validationResult = new ValidationResult([new ValidationError('invalidFromDob', 'Enter a valid date')]);
+      const validationResult = new ValidationResult([
+        new ValidationError('invalidFromDob', 'Enter a valid date'),
+        new ValidationError('invalidToDob', 'Enter a valid date'),
+      ]);
       await postSearchPage(req, res, nextFunctionSpy);
 
       expect(nextFunctionSpy).not.called;


### PR DESCRIPTION
Resolves [BI-12128](https://companieshouse.atlassian.net/browse/BI-12128)

Added ability to: 
- show red error highlights on both date fields if they are both from the future
- show links to both date fields in the error summary if they both error