### PR TITLE
BI-12027-add case type field to search results

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,10 +16,10 @@ export interface BankruptOfficer extends Address {
   surname?: string
   dateOfBirth?: string
   debtorDischargeDate?: string
+  caseType?: string
 }
 export interface FullBankruptOfficer extends BankruptOfficer {
   caseReference?: string
-  caseType?: string
   bankruptcyType?: string
   startDate?: string
   trusteeDischargeDate?: string

--- a/src/views/bankrupt.html
+++ b/src/views/bankrupt.html
@@ -180,6 +180,7 @@
           <th scope="col" class="govuk-table__header">Last name</th>
           <th scope="col" class="govuk-table__header">Date of birth</th>
           <th scope="col" class="govuk-table__header">Postcode</th>
+          <th scope="col" class="govuk-table__header">Case Type</th>
           <th scope="col" class="govuk-table__header govuk--width-one-quarter">Debtor Discharge Date</th>
         </tr>
       </thead>
@@ -190,6 +191,7 @@
           <td class="govuk-table__cell">{{ item.surname }}</td>
           <td class="govuk-table__cell">{{ item.dateOfBirth }}</td>
           <td class="govuk-table__cell">{{ item.postcode }}</td>
+          <td class="govuk-table__cell">{{ item.caseType }}</td>
           <td class="govuk-table__cell">{{ item.debtorDischargeDate }}</td>
         {% endfor %}
       </tr>


### PR DESCRIPTION
Resolves: [BI-12027](https://companieshouse.atlassian.net/browse/BI-12027)

- Move case type field to Bankrupt Officer interface so that field can be displayed called upon and in results page
