### PR TITLE
BI-12051 Retain entered info

### DIFF
--- a/src/controller/bankrupt/bankrupt.controller.ts
+++ b/src/controller/bankrupt/bankrupt.controller.ts
@@ -17,7 +17,7 @@ export const getSearchPage = async (req: Request, res: Response, next: NextFunct
       return await renderSearchResultsPage(req, res, sessionExtraData.filters);
     } 
     const userEmail = userSession.getLoggedInUserEmail(req.session);
-    res.render('bankrupt', { userEmail });
+    res.render('bankrupt', { userEmail, filters: sessionExtraData?.filters });
   } catch (err) {
     logger.error(`${err}`);
     next(err);
@@ -27,19 +27,7 @@ export const getSearchPage = async (req: Request, res: Response, next: NextFunct
 export const postSearchPage = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   
   try {
-    // Get data from request body - dateOfBirth needs to be checked 
-    const { forename1 = '', surname = '', alias = '', postcode = '' } = req.body;
-
-    // Deal with fragmented date of birth
-    const fromDateOfBirth = (req.body["from-dob-dd"] || req.body["from-dob-mm"] || req.body["from-dob-yyyy"]) ?
-      `${req.body["from-dob-yyyy"]}-${req.body["from-dob-mm"]}-${req.body["from-dob-dd"]}` : '';
-    
-    const toDateOfBirth = 
-      (req.body["to-dob-dd"] || req.body["to-dob-mm"] || req.body["to-dob-yyyy"]) ?
-        `${req.body["to-dob-yyyy"]}-${req.body["to-dob-mm"]}-${req.body["to-dob-dd"]}` : '';
-
-    // Set post query data
-    const filters: BankruptOfficerSearchFilters = { forename1, surname, alias, fromDateOfBirth, toDateOfBirth, postcode };
+    const filters: BankruptOfficerSearchFilters = generateFiltersFromBody(req);
     
     let sessionExtraData: undefined | BankruptOfficerSearchSessionExtraData = req.session?.getExtraData(BANKRUPT_OFFICER_SEARCH_SESSION);
     sessionExtraData = {...sessionExtraData, filters};
@@ -54,18 +42,18 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
     let toDobError: undefined | string = undefined;
     let whereTo: undefined | string = undefined;
 
-    if(isValidDate(fromDateOfBirth) === false && isValidDate(toDateOfBirth) === false){
+    if(isValidDate(filters.fromDateOfBirth) === false && isValidDate(filters.toDateOfBirth) === false){
       validationErrors.push(new ValidationError('invalidFromDob', 'Enter a valid date'));
       validationErrors.push(new ValidationError('invalidToDob', 'Enter a valid date'));
       const validationResult = new ValidationResult(validationErrors);
 
-      return res.render('bankrupt', { userEmail, validationResult, whereTo: "invalidFromDob", toDobError: "invalidToDob"});
-    } else if(fromDobInvalid(fromDateOfBirth)){
+      return res.render('bankrupt', { filters, userEmail, validationResult, whereTo: "invalidFromDob", toDobError: "invalidToDob"});
+    } else if(fromDobInvalid(filters.fromDateOfBirth)){
       validationErrors.push(new ValidationError('invalidFromDob', 'Enter a valid date'));
       whereTo = "invalidFromDob";
     }
 
-    if(toDobInvalid(toDateOfBirth,fromDateOfBirth)){
+    if(toDobInvalid(filters.toDateOfBirth,filters.fromDateOfBirth)){
       validationErrors.push(new ValidationError('invalidToDob', 'Enter a valid date'));
       toDobError = "invalidToDob";
     }
@@ -78,6 +66,7 @@ export const postSearchPage = async (req: Request, res: Response, next: NextFunc
     if (validationErrors.length > 0) {
       const validationResult = new ValidationResult(validationErrors);
       const templateVariables = {
+        filters,
         userEmail,
         validationResult,
         ...(whereTo && { whereTo }),
@@ -106,9 +95,25 @@ const renderSearchResultsPage = async (req: Request, res: Response, filters: Ban
       const numOfPages = Math.ceil(totalResults / RESULTS_PER_PAGE);
       paginationData = buildPaginationData(startIndex + 1, numOfPages, SCOTTISH_BANKRUPT_OFFICER);
     }
-    return res.render('bankrupt', { pagination: paginationData, itemsPerPage, startIndex, totalResults, items: formattingOfficersInfo(items), searched: true, userEmail });
+    return res.render('bankrupt', { filters, pagination: paginationData, itemsPerPage, startIndex, totalResults, items: formattingOfficersInfo(items), searched: true, userEmail });
   } else {
     return res.status(results.httpStatusCode).render('error-pages/500');
   } 
 };
 
+export const generateFiltersFromBody = (req: Request): BankruptOfficerSearchFilters => {
+  // Get data from request body - dateOfBirth needs to be checked 
+  const { forename1 = '', surname = '', alias = '', postcode = '' } = req.body;
+
+  // Deal with fragmented date of birth
+  const fromDateOfBirth = (req.body["from-dob-dd"] || req.body["from-dob-mm"] || req.body["from-dob-yyyy"]) ?
+    `${req.body["from-dob-yyyy"]}-${req.body["from-dob-mm"]}-${req.body["from-dob-dd"]}` : '';
+  
+  const toDateOfBirth = 
+    (req.body["to-dob-dd"] || req.body["to-dob-mm"] || req.body["to-dob-yyyy"]) ?
+      `${req.body["to-dob-yyyy"]}-${req.body["to-dob-mm"]}-${req.body["to-dob-dd"]}` : '';
+
+  // Set post query data
+  const filters: BankruptOfficerSearchFilters = { forename1, surname, alias, fromDateOfBirth, toDateOfBirth, postcode };
+  return filters;
+}

--- a/src/utils/validation/validation.ts
+++ b/src/utils/validation/validation.ts
@@ -10,7 +10,7 @@ export function isValidDate(input: moment.MomentInput): boolean | undefined {
   }
 }
   
-export function fromDobInvalid(fromDateOfBirth: string): boolean | undefined{
+export function fromDobInvalid(fromDateOfBirth: string = ''): boolean | undefined{
  
   if(fromDateOfBirth !== ''){
     if(fromDateOfBirth > now.format('YYYY-MM-DD' ) || isValidDate(fromDateOfBirth) === false ){
@@ -19,7 +19,7 @@ export function fromDobInvalid(fromDateOfBirth: string): boolean | undefined{
     return false;
   }
 }
-export function toDobInvalid(toDateOfBirth: string,fromDateOfBirth: string) : boolean | undefined{
+export function toDobInvalid(toDateOfBirth: string = '',fromDateOfBirth: string = '') : boolean | undefined{
   if(toDateOfBirth !== ''){
     if(toDateOfBirth > now.format('YYYY-MM-DD' ) || fromDateOfBirth > toDateOfBirth || isValidDate(toDateOfBirth) === false){
       return true;

--- a/src/views/bankrupt.html
+++ b/src/views/bankrupt.html
@@ -30,7 +30,7 @@
       <span class="govuk-visually-hidden">Error:</span> Enter valid characters
     </p>
     {% endif %}
-    <input class="govuk-input govuk-!-width-one-half" id="forename1" type="text" name="forename1" aria-describedby="forename1-hint">
+    <input class="govuk-input govuk-!-width-one-half" id="forename1" type="text" name="forename1" value="{{filters.forename1}}" aria-describedby="forename1-hint">
   </div>
   <div class="govuk-form-group {% if whereTo === 'noInfo' or (validationResult and validationResult.getErrorForField('surname')) %} govuk-form-group--error {% endif %}" >
     {% if whereTo === 'noInfo' %}
@@ -44,7 +44,7 @@
     </p>
     {% endif %}
     <label class="govuk-label" for="surname">Last name</label>
-    <input class="govuk-input govuk-!-width-one-half" id="surname" type="text" name="surname" aria-describedby="surname-hint">
+    <input class="govuk-input govuk-!-width-one-half" id="surname" type="text" name="surname" value="{{filters.surname}}" aria-describedby="surname-hint">
   </div>
   <div class="govuk-form-group {% if validationResult and validationResult.getErrorForField('alias') %} govuk-form-group--error {% endif %}">
     <label class="govuk-label" for="alias">Alias</label>
@@ -53,7 +53,7 @@
       <span class="govuk-visually-hidden">Error:</span> Enter valid characters
     </p>
     {% endif %}
-    <input class="govuk-input govuk-!-width-one-half" id="alias" type="text" name="alias" aria-describedby="alias-hint">
+    <input class="govuk-input govuk-!-width-one-half" id="alias" type="text" name="alias" value="{{filters.alias}}" aria-describedby="alias-hint">
   </div>
   <div class="govuk-form-group  {% if whereTo === 'invalidFromDob' or whereTo === 'noInfo' %} govuk-form-group--error {% endif %}">
     <fieldset class="govuk-fieldset" role="group" aria-describedby="from-dob-hint">
@@ -79,7 +79,7 @@
               Day
             </label>
             <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="from-dob-dd"
-              name="from-dob-dd" autocomplete="bday-day" type="text"  inputmode="numeric">
+              name="from-dob-dd" value="{{filters.fromDateOfBirth and filters.fromDateOfBirth.split('-')[2]}}" autocomplete="bday-day" type="text"  inputmode="numeric">
           </div>
         </div>
         <div class="govuk-date-input__item">
@@ -88,7 +88,7 @@
               Month
             </label>
             <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="from-dob-mm"
-              name="from-dob-mm" autocomplete="bday-month" type="text"  inputmode="numeric">
+              name="from-dob-mm" value="{{filters.fromDateOfBirth and filters.fromDateOfBirth.split('-')[1]}}" autocomplete="bday-month" type="text"  inputmode="numeric">
           </div>
         </div>
         <div class="govuk-date-input__item">
@@ -97,7 +97,7 @@
               Year
             </label>
             <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="from-dob-yyyy"
-              name="from-dob-yyyy" autocomplete="bday-year" type="text"  inputmode="numeric">
+              name="from-dob-yyyy" value="{{filters.fromDateOfBirth and filters.fromDateOfBirth.split('-')[0]}}" autocomplete="bday-year" type="text"  inputmode="numeric">
             </div>
           </div>
         </div>
@@ -126,7 +126,7 @@
                   Day
                 </label>
                 <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="to-dob-dd"
-                  name="to-dob-dd" autocomplete="bday-day" type="text" inputmode="numeric">
+                  name="to-dob-dd" value="{{filters.toDateOfBirth and filters.toDateOfBirth.split('-')[2]}}" autocomplete="bday-day" type="text" inputmode="numeric">
               </div>
             </div>
             <div class="govuk-date-input__item">
@@ -135,7 +135,7 @@
                   Month
                 </label>
                 <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="to-dob-mm"
-                  name="to-dob-mm" autocomplete="bday-month" type="text"  inputmode="numeric">
+                  name="to-dob-mm" value="{{filters.toDateOfBirth and filters.toDateOfBirth.split('-')[1]}}" autocomplete="bday-month" type="text"  inputmode="numeric">
               </div>
             </div>
             <div class="govuk-date-input__item">
@@ -144,7 +144,7 @@
                   Year
                 </label>
                 <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="to-dob-yyyy"
-                  name="to-dob-yyyy" autocomplete="bday-year" type="text"  inputmode="numeric">
+                  name="to-dob-yyyy" value="{{filters.toDateOfBirth and filters.toDateOfBirth.split('-')[0]}}" autocomplete="bday-year" type="text"  inputmode="numeric">
               </div>
             </div>
           </div>
@@ -159,7 +159,7 @@
       <span class="govuk-visually-hidden">Error:</span> Enter valid characters
     </p>
     {% endif %}
-    <input class="govuk-input govuk-input--width-10" id="postcode" name="postcode" type="text"
+    <input class="govuk-input govuk-input--width-10" id="postcode" name="postcode" value="{{filters.postcode}}" type="text"
       autocomplete="postal-code" aria-describedby="postcode-hint">
   </div>
   <button class="govuk-button" data-module="govuk-button">

--- a/test/controller/bankrupt.spec.ts
+++ b/test/controller/bankrupt.spec.ts
@@ -37,6 +37,7 @@ import { logger } from '../../src/utils';
 import { ValidationResult } from '../../src/controller/bankrupt/ValidationResult';
 import { ValidationError } from '../../src/controller/bankrupt/ValidationError';
 import { INVALID_CHARACTER_ERROR_MESSAGE } from '../../src/config';
+import { generateFiltersFromBody } from '../../src/controller/bankrupt/bankrupt.controller';
 
 chai.use(sinonChai);
 
@@ -78,7 +79,7 @@ describe("BankruptController test suite", () => {
       await getSearchPage(req, res, nextFunctionSpy);
 
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { userEmail: "test@testemail.com" });
+      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', {filters: undefined, userEmail: "test@testemail.com" });
     });
 
     it('should catch any error and call next function', async () => {
@@ -102,8 +103,9 @@ describe("BankruptController test suite", () => {
       sinon.stub(userSession, "getLoggedInUserEmail").returns('test@testemail.com');
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { searched: true, ...BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS, ...PAGINATION_RESULTS, userEmail: "test@testemail.com"  });
+      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { filters, searched: true, ...BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS, ...PAGINATION_RESULTS, userEmail: "test@testemail.com" });
     });
   
     it("should render the bankrupt officer search page with list of officers when DOB filters are used", async () => {
@@ -113,8 +115,9 @@ describe("BankruptController test suite", () => {
       sinon.stub(userSession, "getLoggedInUserEmail").returns('test@testemail.com');
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { searched: true, ...BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS, ...PAGINATION_RESULTS, userEmail: "test@testemail.com" });
+      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { filters, searched: true, ...BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS, ...PAGINATION_RESULTS, userEmail: "test@testemail.com" });
     });
 
 
@@ -125,8 +128,9 @@ describe("BankruptController test suite", () => {
       sinon.stub(userSession, "getLoggedInUserEmail").returns('test@testemail.com');
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { searched: true, ...BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS, ...PAGINATION_RESULTS, userEmail: "test@testemail.com" });
+      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { filters, searched: true, ...BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS, ...PAGINATION_RESULTS, userEmail: "test@testemail.com" });
     });
 
     it("should render the bankrupt officer search page from only TO_DOB filters with the list of officers", async () => {
@@ -136,8 +140,9 @@ describe("BankruptController test suite", () => {
       sinon.stub(userSession, "getLoggedInUserEmail").returns('test@testemail.com');
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { searched: true, ...BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS, ...PAGINATION_RESULTS, userEmail: "test@testemail.com" });
+      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { filters, searched: true, ...BANKRUPT_OFFICER_SEARCH_PAGE_RESULTS, ...PAGINATION_RESULTS, userEmail: "test@testemail.com" });
     });
 
     it("should renders the bankrupt officer search page with no officers", async () => {
@@ -147,8 +152,9 @@ describe("BankruptController test suite", () => {
 
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { searched: true, ...BANKRUPT_OFFICER_SEARCH_NO_PAGE_RESULTS, pagination: undefined, userEmail: "test@testemail.com" });
+      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { filters, searched: true, ...BANKRUPT_OFFICER_SEARCH_NO_PAGE_RESULTS, pagination: undefined, userEmail: "test@testemail.com" });
     });
 
 
@@ -159,8 +165,9 @@ describe("BankruptController test suite", () => {
 
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWith('bankrupt', { searched: true, ...BANKRUPT_OFFICER_SEARCH_NO_PAGE_RESULTS, pagination: undefined, userEmail: "test@testemail.com" });
+      expect(res.render).to.have.been.calledOnceWith('bankrupt', { filters, searched: true, ...BANKRUPT_OFFICER_SEARCH_NO_PAGE_RESULTS, pagination: undefined, userEmail: "test@testemail.com" });
     });
 
     it("should render the bankrupt officer search page with errors if the text fields contain invalid characters", async () => {
@@ -170,8 +177,9 @@ describe("BankruptController test suite", () => {
 
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { validationResult, userEmail: "test@testemail.com" });
+      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { filters, validationResult, userEmail: "test@testemail.com" });
     });
 
     it("should renders the bankrupt officer search page with errors when no filters are used", async () => {
@@ -180,8 +188,10 @@ describe("BankruptController test suite", () => {
       sinon.stub(userSession, "getLoggedInUserEmail").returns('test@testemail.com');
       const validationResult = new ValidationResult([new ValidationError('noInfo', 'Enter a Date Of Birth or Last Name')]);
       await postSearchPage(req, res, nextFunctionSpy);
+      
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { whereTo: "noInfo", validationResult, userEmail: "test@testemail.com" });
+      expect(res.render).to.have.been.calledOnceWithExactly('bankrupt', { filters, whereTo: "noInfo", validationResult, userEmail: "test@testemail.com" });
     });
 
 
@@ -192,8 +202,9 @@ describe("BankruptController test suite", () => {
       const validationResult = new ValidationResult([new ValidationError('invalidFromDob', 'Enter a valid date')]);
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { whereTo: "invalidFromDob", validationResult, userEmail: "test@testemail.com"});
+      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { filters, whereTo: "invalidFromDob", validationResult, userEmail: "test@testemail.com"});
     });
 
     it("should render the bankrupt officer search page with errors when invalid date fromDob MM filters are used", async () => {
@@ -203,8 +214,9 @@ describe("BankruptController test suite", () => {
       const validationResult = new ValidationResult([new ValidationError('invalidFromDob', 'Enter a valid date')]);
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { whereTo: "invalidFromDob", validationResult, userEmail: "test@testemail.com"});
+      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { filters, whereTo: "invalidFromDob", validationResult, userEmail: "test@testemail.com"});
     });
 
     it("should render the bankrupt officer search page with errors when invalid date fromDob YYYY filters are used", async () => {
@@ -214,8 +226,9 @@ describe("BankruptController test suite", () => {
       const validationResult = new ValidationResult([new ValidationError('invalidFromDob', 'Enter a valid date')]);
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { whereTo: "invalidFromDob", validationResult, userEmail: "test@testemail.com"});
+      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { filters, whereTo: "invalidFromDob", validationResult, userEmail: "test@testemail.com"});
     });
 
     it("should render the bankrupt officer search page with errors when invalid toDob DD filters are used", async () => {
@@ -225,8 +238,9 @@ describe("BankruptController test suite", () => {
       const validationResult = new ValidationResult([new ValidationError('invalidToDob', 'Enter a valid date')]);
       await postSearchPage(req, res, nextFunctionSpy);
       
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { toDobError: "invalidToDob", validationResult, userEmail: "test@testemail.com"});
+      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { filters, toDobError: "invalidToDob", validationResult, userEmail: "test@testemail.com"});
     });
 
     it("should render the bankrupt officer search page with errors when invalid toDob MM filters are used", async () => {
@@ -236,8 +250,9 @@ describe("BankruptController test suite", () => {
       const validationResult = new ValidationResult([new ValidationError('invalidToDob', 'Enter a valid date')]);
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { toDobError: "invalidToDob", validationResult, userEmail: "test@testemail.com"});
+      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { filters, toDobError: "invalidToDob", validationResult, userEmail: "test@testemail.com"});
     });
 
     it("should render the bankrupt officer search page with errors when invalid toDob YYYY filters are used", async () => {
@@ -247,8 +262,9 @@ describe("BankruptController test suite", () => {
       const validationResult = new ValidationResult([new ValidationError('invalidToDob', 'Enter a valid date')]);
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { toDobError: "invalidToDob", validationResult, userEmail: "test@testemail.com"});
+      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { filters, toDobError: "invalidToDob", validationResult, userEmail: "test@testemail.com"});
     });
     
 
@@ -262,8 +278,9 @@ describe("BankruptController test suite", () => {
       ]);
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { whereTo: "invalidFromDob" , toDobError: "invalidToDob", validationResult, userEmail: "test@testemail.com"});
+      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { filters, whereTo: "invalidFromDob" , toDobError: "invalidToDob", validationResult, userEmail: "test@testemail.com"});
     });
 
     it("should render the bankrupt officer search page with errors when toDob is before fromDob", async () => {
@@ -273,8 +290,9 @@ describe("BankruptController test suite", () => {
       const validationResult = new ValidationResult([new ValidationError('invalidToDob', 'Enter a valid date')]);
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { toDobError: "invalidToDob", validationResult, userEmail: "test@testemail.com"});
+      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { filters, toDobError: "invalidToDob", validationResult, userEmail: "test@testemail.com"});
     });
 
 
@@ -285,8 +303,9 @@ describe("BankruptController test suite", () => {
       const validationResult = new ValidationResult([new ValidationError('invalidFromDob', 'Enter a valid date')]);
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { whereTo: "invalidFromDob", validationResult, userEmail: "test@testemail.com"});
+      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { filters, whereTo: "invalidFromDob", validationResult, userEmail: "test@testemail.com"});
     });
 
     it("should render the bankrupt officer search page with errors when toDob date is from the future", async () => {
@@ -296,33 +315,46 @@ describe("BankruptController test suite", () => {
       const validationResult = new ValidationResult([new ValidationError('invalidToDob', 'Enter a valid date')]);
       await postSearchPage(req, res, nextFunctionSpy);
 
+      const filters = generateFiltersFromBody(req);
       expect(nextFunctionSpy).not.called;
-      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { toDobError: "invalidToDob", validationResult, userEmail: "test@testemail.com"});
+      expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { filters, toDobError: "invalidToDob", validationResult, userEmail: "test@testemail.com"});
     });
 
   });
 
-  it("should render the bankrupt officer search page with errors when non exisitant from date used", async () => {
+  it("should render the bankrupt officer search page with errors when non existant from date used", async () => {
     req.body = mockSearchQueryNonExistantFromDob.filters;
     sinon.stub(BadosService.prototype, 'getBankruptOfficers').rejects(mockPostResponse[404]);
     sinon.stub(userSession, "getLoggedInUserEmail").returns('test@testemail.com');
     const validationResult = new ValidationResult([new ValidationError('invalidFromDob', 'Enter a valid date')]);
     await postSearchPage(req, res, nextFunctionSpy);
 
+    const filters = generateFiltersFromBody(req);
     expect(nextFunctionSpy).not.called;
-    expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { whereTo: "invalidFromDob", validationResult, userEmail: "test@testemail.com"});
+    expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", {
+      whereTo: "invalidFromDob",
+      validationResult,
+      userEmail: "test@testemail.com",
+      filters
+    });
   });
 
 
-  it("should render the bankrupt officer search page with errors when non exisitant to date used", async () => {
+  it("should render the bankrupt officer search page with errors when non existant to date used", async () => {
     req.body = mockSearchQueryNonExistantToDob.filters;
     sinon.stub(BadosService.prototype, 'getBankruptOfficers').rejects(mockPostResponse[404]);
     sinon.stub(userSession, "getLoggedInUserEmail").returns('test@testemail.com');
     const validationResult = new ValidationResult([new ValidationError('invalidToDob', 'Enter a valid date')]);
     await postSearchPage(req, res, nextFunctionSpy);
 
+    const filters = generateFiltersFromBody(req);
     expect(nextFunctionSpy).not.called;
-    expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", { toDobError: "invalidToDob", validationResult, userEmail: "test@testemail.com"});
+    expect(res.render).to.have.been.calledOnceWithExactly("bankrupt", {
+      toDobError: "invalidToDob",
+      validationResult,
+      userEmail: "test@testemail.com",
+      filters
+    });
   });
 
 


### PR DESCRIPTION
Resolves [BI-12051](https://companieshouse.atlassian.net/browse/BI-12051)

Allows the information typed by the users to persist in the HTML so they can refine their search/amend any validation errors they encounter.